### PR TITLE
feat: alertas de sensor en silencio con escalada, snooze y badge en dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **Alertas de sensor en silencio** — Cuando las lecturas de un paciente dejan de llegar (teléfono lejos del sensor, sensor expirado o fallado), el monitor ya no lo ignora: aviso de revisión a los 60 min, pregunta a las 3 h ("¿el sensor terminó su vida útil o se alejó del celular?"), recordatorio cada 24 h mientras siga mudo, y aviso de recuperación al volver las lecturas. Configurable bajo `alerts.silence` (umbrales, mensajes, on/off). Las alertas se registran en el historial con nivel `silence_*`.
+  - **Snooze por paciente desde el dashboard** — botón 🔕 con selector (24 h / 7 días / hasta nuevo sensor). El mute "hasta nuevo sensor" se limpia solo cuando el sensor de reemplazo empieza a reportar. Endpoints `POST /api/patients/{id}/silence/mute` y `/unmute` (sesión + CSRF).
+  - **Badge en el dashboard** — las tarjetas muestran "📡 sin datos hace Xh" en ámbar (vista moderna y vista senior); `/api/patients` expone el objeto `silence` por paciente, calculado por request para no congelarse justo durante un silencio.
 - **Historial continuo de lecturas de glucosa** — `src/reading_history.py` persiste todas las lecturas en `reading_history.db` (SQLite). Ruta configurable con `reading_history_db` en `config.yaml`.
 - **Endpoint `GET /api/patients/{id}/history?hours=N`** — devuelve lecturas del período indicado (1–8760 h ≈ 1 año). Aplica downsampling automático para rangos > 24 h (cubos de 15 min / 30 min / 1 h) para mantener la respuesta manejable.
 - **Endpoint `GET /api/patients/{id}/history/export?format={csv|json}&days=N`** — exporta el historial completo a resolución nativa como archivo descargable. CSV con BOM (compatible Excel); JSON con envelope de metadatos. Ventana máxima: 365 días.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Para **familias** donde uno o varios miembros usan un sensor FreeStyle Libre y t
 - 🌍 Soporte de 12 regiones de LibreLinkUp con auto-redirect
 - ⚠️ Alertas configurables por umbral bajo/alto con cooldown anti-spam
 - 📈 Alertas por tendencia (subiendo rápido, bajando rápido, etc.)
+- 📡 **Alertas de sensor en silencio** — escalada cuando dejan de llegar lecturas (revisión a los 60 min → pregunta a las 3 h → recordatorio cada 24 h → aviso de recuperación), con snooze por paciente desde el dashboard (24 h / 7 días / hasta nuevo sensor)
 - 💬 Salidas: **Telegram**, **Webhook** (Pushover-compatible), **WhatsApp Cloud API**
 - 🔔 Notificaciones push en el navegador (Web Push / VAPID) — suscripción desde el dashboard
 - 📱 **PWA instalable en Android** (y escritorio) — icono en pantalla de inicio, modo standalone, soporte offline
@@ -691,6 +692,8 @@ Requieren sesión autenticada (cookie `session_token`):
 | `GET` | `/api/patients/{id}/history` | Serie temporal de lecturas (con downsampling server-side) |
 | `GET` | `/api/patients/{id}/history/export` | Export CSV/JSON del histórico (streaming) |
 | `GET` | `/api/patients/{id}/metrics` | Métricas glucémicas del período (TIR, GMI, CV, MAGE…) |
+| `POST` | `/api/patients/{id}/silence/mute` | Silenciar alertas de sensor en silencio (`{"duration": "24h"\|"7d"\|"recovery"}`) |
+| `POST` | `/api/patients/{id}/silence/unmute` | Reactivar alertas de sensor en silencio |
 | `GET` | `/i18n/{filename}` | Recursos de internacionalización (sin auth) |
 
 ### Ejecutar el Dashboard

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -31,6 +31,15 @@ alerts:
       falling: "📉 {patient_name}: glucosa en {value} mg/dL {trend} — bajando, posible hipo"
       rising_fast: "🔺 {patient_name}: glucosa en {value} mg/dL {trend} — SUBIENDO RÁPIDO"
       rising: "📈 {patient_name}: glucosa en {value} mg/dL {trend} — subiendo, posible hiper"
+  # Sensor-silence alerts: warn when a patient's readings STOP arriving
+  # (phone away from sensor, sensor expired/failed). Check notice at 60 min,
+  # question at 3h, reminder every 24h while silent, recovery notice when
+  # readings resume. Snooze per patient from the dashboard. Enabled by default.
+  silence:
+    enabled: true
+    check_after_minutes: 60
+    ask_after_minutes: 180
+    remind_every_hours: 24
 
 outputs:
   - type: telegram

--- a/src/alert_engine.py
+++ b/src/alert_engine.py
@@ -199,10 +199,15 @@ DEFAULT_SILENCE_MESSAGES = {
 
 
 def get_silence_config(config: dict | None) -> dict:
-    """Return the alerts.silence section merged over defaults."""
+    """Return the alerts.silence section merged over defaults.
+
+    ``None`` values are ignored so an explicit YAML ``null`` cannot override
+    a default and break the threshold comparisons downstream.
+    """
     merged = dict(DEFAULT_SILENCE_CONFIG)
     if config:
-        merged.update(config.get("alerts", {}).get("silence", {}) or {})
+        section = config.get("alerts", {}).get("silence", {}) or {}
+        merged.update({k: v for k, v in section.items() if v is not None})
     return merged
 
 

--- a/src/alert_engine.py
+++ b/src/alert_engine.py
@@ -174,3 +174,139 @@ def build_message(glucose_value: int, level: str, trend_arrow: str,
         )
     except KeyError:
         return template
+
+
+# ── Sensor-silence alerts ────────────────────────────────────────────────────
+#
+# A patient whose readings stop arriving is indistinguishable from "all good"
+# unless someone says otherwise. Two escalation stages, a periodic reminder,
+# and a recovery notice. Per-patient snooze (mute) is honoured here; the
+# mute itself is set from the dashboard.
+
+DEFAULT_SILENCE_CONFIG = {
+    "enabled": True,
+    "check_after_minutes": 60,
+    "ask_after_minutes": 180,
+    "remind_every_hours": 24,
+}
+
+DEFAULT_SILENCE_MESSAGES = {
+    "stage1": "📡 {patient_name}: sin lecturas desde hace {silence_human} — revisa que el teléfono esté cerca del sensor",
+    "stage2": "⚠️ {patient_name}: {silence_human} sin lecturas — ¿el sensor terminó su vida útil o se alejó del celular por un periodo prolongado? Si es esperado, puedes silenciar este aviso desde el dashboard",
+    "reminder": "⚠️ {patient_name}: el sensor lleva {silence_human} sin reportar",
+    "recovered": "🟢 {patient_name}: sensor reportando de nuevo ({value} mg/dL {trend})",
+}
+
+
+def get_silence_config(config: dict | None) -> dict:
+    """Return the alerts.silence section merged over defaults."""
+    merged = dict(DEFAULT_SILENCE_CONFIG)
+    if config:
+        merged.update(config.get("alerts", {}).get("silence", {}) or {})
+    return merged
+
+
+def silence_minutes(reading_timestamp: datetime, now: datetime | None = None) -> float:
+    """Minutes elapsed since the patient's most recent reading."""
+    now = now or datetime.now(timezone.utc)
+    return (now - reading_timestamp).total_seconds() / 60
+
+
+def is_silence_muted(silence_state: dict, now: datetime | None = None) -> bool:
+    """True if the caregiver muted silence alerts and the mute is still active.
+
+    ``muted_until`` is either an ISO timestamp or the literal ``"recovery"``
+    (mute until readings resume; cleared by the recovery path in run_once).
+    """
+    muted_until = (silence_state or {}).get("muted_until")
+    if not muted_until:
+        return False
+    if muted_until == "recovery":
+        return True
+    now = now or datetime.now(timezone.utc)
+    try:
+        return datetime.fromisoformat(muted_until) > now
+    except (ValueError, TypeError):
+        return False
+
+
+def evaluate_silence(reading_timestamp: datetime, silence_state: dict,
+                     config: dict | None = None,
+                     now: datetime | None = None) -> str | None:
+    """Decide which silence action (if any) to emit for a patient.
+
+    Returns ``"stage1"`` (check phone/sensor), ``"stage2"`` (ask whether the
+    sensor ended its life or is away), ``"reminder"`` (still silent, every
+    ``remind_every_hours``), or ``None``. Recovery is handled by the caller
+    when a fresh reading arrives.
+
+    Stage transitions skip ahead naturally: a patient first evaluated after
+    3h of silence gets ``stage2`` directly, without a redundant ``stage1``.
+    """
+    cfg = get_silence_config(config)
+    if not cfg.get("enabled", True):
+        return None
+
+    silence_state = silence_state or {}
+    if is_silence_muted(silence_state, now=now):
+        return None
+
+    now = now or datetime.now(timezone.utc)
+    minutes = silence_minutes(reading_timestamp, now=now)
+    stage = silence_state.get("stage")
+
+    if minutes >= cfg["ask_after_minutes"]:
+        if stage != "stage2":
+            return "stage2"
+        last = silence_state.get("last_alert_time")
+        try:
+            last_dt = datetime.fromisoformat(last) if last else None
+        except (ValueError, TypeError):
+            last_dt = None
+        if last_dt is None:
+            return "reminder"
+        if (now - last_dt).total_seconds() >= cfg["remind_every_hours"] * 3600:
+            return "reminder"
+        return None
+
+    if minutes >= cfg["check_after_minutes"]:
+        return "stage1" if stage is None else None
+
+    return None
+
+
+def humanize_minutes(minutes: float) -> str:
+    """Human-friendly Spanish duration: '45 min', '3h', '2 días'."""
+    if minutes < 120:
+        return f"{int(minutes)} min"
+    hours = minutes / 60
+    if hours < 48:
+        return f"{int(hours)}h"
+    return f"{int(hours // 24)} días"
+
+
+def build_silence_message(action: str, patient_name: str, minutes: float,
+                          config: dict | None = None,
+                          glucose_value: int | None = None,
+                          trend_arrow: str = "") -> str:
+    """Render the message for a silence *action* using configurable templates.
+
+    Templates live under ``alerts.silence.messages.<action>`` and fall back to
+    Spanish defaults. Placeholders: ``{patient_name}``, ``{silence_human}``,
+    ``{silence_minutes}``, and for ``recovered`` also ``{value}``/``{trend}``.
+    """
+    messages = {}
+    if config:
+        messages = config.get("alerts", {}).get("silence", {}).get("messages", {}) or {}
+    template = messages.get(action) or DEFAULT_SILENCE_MESSAGES.get(action, "")
+    try:
+        return _formatter.format(
+            template,
+            patient_name=patient_name,
+            silence_human=humanize_minutes(minutes),
+            silence_minutes=int(minutes),
+            value=glucose_value if glucose_value is not None else "",
+            trend=trend_arrow,
+        )
+    except KeyError:
+        return template

--- a/src/api.py
+++ b/src/api.py
@@ -32,7 +32,7 @@ import stat
 import threading
 import time
 from contextlib import asynccontextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Literal, Optional
 
@@ -52,7 +52,8 @@ from src.connection_tester import test_librelinkup as _test_librelinkup
 from src.connection_tester import test_telegram as _test_telegram
 from src.crypto import decrypt_value, encrypt_value, is_encrypted
 from src.outputs.webpush import WebPushOutput, get_vapid_public_key
-from src.paths import get_cache_path, get_db_path, get_reading_history_db_path
+from src.paths import get_cache_path, get_db_path, get_reading_history_db_path, get_state_path
+from src.state import load_state, save_state
 import src.push_subscriptions as _push_subs
 from src import reading_history as _reading_history
 from src.setup_status import is_setup_complete
@@ -411,12 +412,49 @@ def _get_color(level: str, trend_alert: str) -> str:
         return "yellow"
     return "green"
 
+def _attach_silence(patients: list) -> None:
+    """Attach per-request sensor-silence info to patient payloads.
+
+    Computed at request time — NOT at cache-reload time — because during an
+    actual silence the cache file stops changing, so anything computed on
+    reload would freeze at the exact moment it matters most.
+    """
+    sil_cfg = alert_engine.get_silence_config(_config)
+    try:
+        state = load_state(get_state_path(_config))
+    except Exception:
+        state = {}
+    now = datetime.now(timezone.utc)
+    for r in patients:
+        minutes = None
+        ts_raw = r.get("timestamp")
+        if ts_raw:
+            try:
+                ts = datetime.fromisoformat(str(ts_raw))
+                if ts.tzinfo is None:
+                    ts = ts.replace(tzinfo=timezone.utc)
+                minutes = int(alert_engine.silence_minutes(ts, now=now))
+            except (ValueError, TypeError):
+                minutes = None
+        patient_state = state.get(r.get("patient_id", ""), {}) or {}
+        sil_state = patient_state.get("silence", {}) or {}
+        r["silence"] = {
+            "enabled": bool(sil_cfg.get("enabled", True)),
+            "minutes": minutes,
+            "stage": sil_state.get("stage"),
+            "muted_until": sil_state.get("muted_until"),
+            "check_after_minutes": sil_cfg["check_after_minutes"],
+            "ask_after_minutes": sil_cfg["ask_after_minutes"],
+        }
+
+
 @app.get("/api/patients", response_class=JSONResponse)
 def get_patients():
     """Return all patients with their latest readings."""
     _load_and_enrich_cache()
     with _cache_lock:
         patients = list(_readings_cache.values())
+    _attach_silence(patients)
     return {"patients": patients, "count": len(patients)}
 
 @app.get("/api/patients/{patient_id}", response_class=JSONResponse)
@@ -427,7 +465,76 @@ def get_patient(patient_id: str):
         reading = _readings_cache.get(patient_id)
     if not reading:
         raise HTTPException(status_code=404, detail="Patient not found")
+    _attach_silence([reading])
     return reading
+
+
+# ── Sensor-silence mute (caregiver snooze) ───────────────────────────────────
+
+_MUTE_DURATIONS = {"24h": timedelta(hours=24), "7d": timedelta(days=7)}
+
+
+@app.post("/api/patients/{patient_id}/silence/mute", response_class=JSONResponse)
+async def api_silence_mute(patient_id: str, request: Request):
+    """Mute sensor-silence alerts for *patient_id*.
+
+    Body: ``{"duration": "24h" | "7d" | "recovery"}``. ``"recovery"`` mutes
+    until readings resume (the monitor clears it automatically on the first
+    fresh reading — e.g. when a replacement sensor starts up).
+    """
+    _validate_csrf(request)
+    try:
+        data = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="JSON inválido")
+    duration = str(data.get("duration", "")).strip()
+    if duration == "recovery":
+        muted_until = "recovery"
+    elif duration in _MUTE_DURATIONS:
+        muted_until = (datetime.now(timezone.utc) + _MUTE_DURATIONS[duration]).isoformat()
+    else:
+        raise HTTPException(
+            status_code=422, detail="duration debe ser '24h', '7d' o 'recovery'"
+        )
+
+    _load_and_enrich_cache()
+    with _cache_lock:
+        known = patient_id in _readings_cache
+    if not known:
+        raise HTTPException(status_code=404, detail="Patient not found")
+
+    state_path = get_state_path(_config)
+    state = load_state(state_path)
+    patient_state = dict(state.get(patient_id, {}))
+    silence = dict(patient_state.get("silence", {}))
+    silence["muted_until"] = muted_until
+    patient_state["silence"] = silence
+    state[patient_id] = patient_state
+    save_state(state_path, state)
+    logger.info("Silence alerts muted for %s until %s", patient_id, muted_until)
+    return {"success": True, "patient_id": patient_id, "muted_until": muted_until}
+
+
+@app.post("/api/patients/{patient_id}/silence/unmute", response_class=JSONResponse)
+async def api_silence_unmute(patient_id: str, request: Request):
+    """Remove an active sensor-silence mute for *patient_id*."""
+    _validate_csrf(request)
+    state_path = get_state_path(_config)
+    state = load_state(state_path)
+    patient_state = dict(state.get(patient_id, {}))
+    silence = dict(patient_state.get("silence", {}))
+    silence.pop("muted_until", None)
+    if silence:
+        patient_state["silence"] = silence
+    else:
+        patient_state.pop("silence", None)
+    if patient_state:
+        state[patient_id] = patient_state
+    else:
+        state.pop(patient_id, None)
+    save_state(state_path, state)
+    logger.info("Silence alerts unmuted for %s", patient_id)
+    return {"success": True, "patient_id": patient_id, "muted_until": None}
 
 
 @app.get("/api/patients/{patient_id}/history", response_class=JSONResponse)

--- a/src/api.py
+++ b/src/api.py
@@ -53,7 +53,7 @@ from src.connection_tester import test_telegram as _test_telegram
 from src.crypto import decrypt_value, encrypt_value, is_encrypted
 from src.outputs.webpush import WebPushOutput, get_vapid_public_key
 from src.paths import get_cache_path, get_db_path, get_reading_history_db_path, get_state_path
-from src.state import load_state, save_state
+from src.state import load_state, save_state, state_lock
 import src.push_subscriptions as _push_subs
 from src import reading_history as _reading_history
 from src.setup_status import is_setup_complete
@@ -504,13 +504,14 @@ async def api_silence_mute(patient_id: str, request: Request):
         raise HTTPException(status_code=404, detail="Patient not found")
 
     state_path = get_state_path(_config)
-    state = load_state(state_path)
-    patient_state = dict(state.get(patient_id, {}))
-    silence = dict(patient_state.get("silence", {}))
-    silence["muted_until"] = muted_until
-    patient_state["silence"] = silence
-    state[patient_id] = patient_state
-    save_state(state_path, state)
+    with state_lock(state_path):
+        state = load_state(state_path)
+        patient_state = dict(state.get(patient_id, {}))
+        silence = dict(patient_state.get("silence", {}))
+        silence["muted_until"] = muted_until
+        patient_state["silence"] = silence
+        state[patient_id] = patient_state
+        save_state(state_path, state)
     logger.info("Silence alerts muted for %s until %s", patient_id, muted_until)
     return {"success": True, "patient_id": patient_id, "muted_until": muted_until}
 
@@ -519,20 +520,32 @@ async def api_silence_mute(patient_id: str, request: Request):
 async def api_silence_unmute(patient_id: str, request: Request):
     """Remove an active sensor-silence mute for *patient_id*."""
     _validate_csrf(request)
+
+    _load_and_enrich_cache()
+    with _cache_lock:
+        known = patient_id in _readings_cache
+    if not known:
+        raise HTTPException(status_code=404, detail="Patient not found")
+
     state_path = get_state_path(_config)
-    state = load_state(state_path)
-    patient_state = dict(state.get(patient_id, {}))
-    silence = dict(patient_state.get("silence", {}))
-    silence.pop("muted_until", None)
-    if silence:
-        patient_state["silence"] = silence
-    else:
-        patient_state.pop("silence", None)
-    if patient_state:
-        state[patient_id] = patient_state
-    else:
-        state.pop(patient_id, None)
-    save_state(state_path, state)
+    with state_lock(state_path):
+        state = load_state(state_path)
+        patient_state = dict(state.get(patient_id, {}))
+        silence = dict(patient_state.get("silence", {}))
+        if "muted_until" not in silence:
+            # Nothing to un-mute: keep the endpoint idempotent without an
+            # unnecessary state.json write.
+            return {"success": True, "patient_id": patient_id, "muted_until": None}
+        silence.pop("muted_until", None)
+        if silence:
+            patient_state["silence"] = silence
+        else:
+            patient_state.pop("silence", None)
+        if patient_state:
+            state[patient_id] = patient_state
+        else:
+            state.pop(patient_id, None)
+        save_state(state_path, state)
     logger.info("Silence alerts unmuted for %s", patient_id)
     return {"success": True, "patient_id": patient_id, "muted_until": None}
 

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -132,6 +132,49 @@ def validate_config(config: Any) -> list[str]:
                                     f"alerts.trend.messages.{key} must be a string, got {type(tmpl).__name__}"
                                 )
 
+        # --- alerts.silence (optional) ---
+        silence = alerts.get("silence")
+        if silence is not None:
+            if not isinstance(silence, dict):
+                errors.append("alerts.silence must be a mapping (dict)")
+            else:
+                if "enabled" in silence and not isinstance(silence["enabled"], bool):
+                    errors.append(
+                        f"alerts.silence.enabled must be a boolean, got {type(silence['enabled']).__name__}"
+                    )
+                for field in ("check_after_minutes", "ask_after_minutes", "remind_every_hours"):
+                    val = silence.get(field)
+                    if val is not None:
+                        if not isinstance(val, (int, float)):
+                            errors.append(
+                                f"alerts.silence.{field} must be a number, got {type(val).__name__}"
+                            )
+                        elif val <= 0:
+                            errors.append(f"alerts.silence.{field} must be > 0, got {val}")
+                check_m = silence.get("check_after_minutes")
+                ask_m = silence.get("ask_after_minutes")
+                if (
+                    isinstance(check_m, (int, float))
+                    and isinstance(ask_m, (int, float))
+                    and check_m > 0
+                    and ask_m > 0
+                    and ask_m <= check_m
+                ):
+                    errors.append(
+                        f"alerts.silence.ask_after_minutes ({ask_m}) must be greater than "
+                        f"check_after_minutes ({check_m})"
+                    )
+                silence_messages = silence.get("messages")
+                if silence_messages is not None:
+                    if not isinstance(silence_messages, dict):
+                        errors.append("alerts.silence.messages must be a mapping (dict)")
+                    else:
+                        for key, tmpl in silence_messages.items():
+                            if not isinstance(tmpl, str):
+                                errors.append(
+                                    f"alerts.silence.messages.{key} must be a string, got {type(tmpl).__name__}"
+                                )
+
     # --- monitoring section (optional) ---
     _VALID_MODES = {"cron", "daemon", "full", "dashboard"}
     monitoring = config.get("monitoring")

--- a/src/config_schema.py
+++ b/src/config_schema.py
@@ -143,14 +143,18 @@ def validate_config(config: Any) -> list[str]:
                         f"alerts.silence.enabled must be a boolean, got {type(silence['enabled']).__name__}"
                     )
                 for field in ("check_after_minutes", "ask_after_minutes", "remind_every_hours"):
-                    val = silence.get(field)
-                    if val is not None:
-                        if not isinstance(val, (int, float)):
-                            errors.append(
-                                f"alerts.silence.{field} must be a number, got {type(val).__name__}"
-                            )
-                        elif val <= 0:
-                            errors.append(f"alerts.silence.{field} must be > 0, got {val}")
+                    if field not in silence:
+                        continue
+                    val = silence[field]
+                    # Explicit null and booleans are rejected: a YAML `null`
+                    # would override the runtime default and break threshold
+                    # comparisons, and bool is a subclass of int.
+                    if val is None or isinstance(val, bool) or not isinstance(val, (int, float)):
+                        errors.append(
+                            f"alerts.silence.{field} must be a number, got {type(val).__name__}"
+                        )
+                    elif val <= 0:
+                        errors.append(f"alerts.silence.{field} must be > 0, got {val}")
                 check_m = silence.get("check_after_minutes")
                 ask_m = silence.get("ask_after_minutes")
                 if (

--- a/src/dashboard/i18n/en.json
+++ b/src/dashboard/i18n/en.json
@@ -130,5 +130,14 @@
   "setup.step1.dashboard_hint_middle": ". It can differ from your LibreLinkUp password and will be stored hashed (PBKDF2) in ",
   "setup.step1.dashboard_hint_suffix": ".",
   "setup.step3.hint_prefix": "Choose how you want to receive glucose alerts. You can skip this step and configure it later by editing ",
-  "setup.step3.hint_suffix": "."
+  "setup.step3.hint_suffix": ".",
+  "silence.days": "days",
+  "silence.no_data_since": "No data for {0}",
+  "silence.mute_24h": "Mute 24h",
+  "silence.mute_7d": "Mute 7 days",
+  "silence.mute_recovery": "Until new sensor",
+  "silence.muted_until": "🔕 Alerts muted until {0}",
+  "silence.muted_recovery": "🔕 Muted until the sensor returns",
+  "silence.unmute": "Re-enable alerts",
+  "alert_level.silence": "SENSOR"
 }

--- a/src/dashboard/i18n/es.json
+++ b/src/dashboard/i18n/es.json
@@ -130,5 +130,14 @@
   "setup.step1.dashboard_hint_middle": ". Puede ser diferente a tu contraseña de LibreLinkUp y se almacenará derivada con hash (PBKDF2) en ",
   "setup.step1.dashboard_hint_suffix": ".",
   "setup.step3.hint_prefix": "Elige cómo quieres recibir alertas de glucosa. Puedes omitir este paso y configurarlo más tarde editando ",
-  "setup.step3.hint_suffix": "."
+  "setup.step3.hint_suffix": ".",
+  "silence.days": "días",
+  "silence.no_data_since": "Sin datos desde hace {0}",
+  "silence.mute_24h": "Silenciar 24h",
+  "silence.mute_7d": "Silenciar 7 días",
+  "silence.mute_recovery": "Hasta nuevo sensor",
+  "silence.muted_until": "🔕 Avisos silenciados hasta {0}",
+  "silence.muted_recovery": "🔕 Silenciado hasta que vuelva el sensor",
+  "silence.unmute": "Reactivar avisos",
+  "alert_level.silence": "SENSOR"
 }

--- a/src/dashboard/i18n/i18n.js
+++ b/src/dashboard/i18n/i18n.js
@@ -13,6 +13,15 @@
   // ── Embedded translation tables ──────────────────────────────────────────
   var TRANSLATIONS = {
     es: {
+      'alert_level.silence': 'SENSOR',
+      'silence.days': 'días',
+      'silence.mute_24h': 'Silenciar 24h',
+      'silence.mute_7d': 'Silenciar 7 días',
+      'silence.mute_recovery': 'Hasta nuevo sensor',
+      'silence.muted_recovery': '🔕 Silenciado hasta que vuelva el sensor',
+      'silence.muted_until': '🔕 Avisos silenciados hasta {0}',
+      'silence.no_data_since': 'Sin datos desde hace {0}',
+      'silence.unmute': 'Reactivar avisos',
       'config.note.test_emphasis': 'actualmente escritos',
       'config.note.test_prefix': 'La prueba usa los valores ',
       'config.note.test_suffix': ' en el formulario, incluso si aún no se han guardado.',
@@ -314,6 +323,15 @@
       'help.docs_link': 'Documentación',
     },
     en: {
+      'alert_level.silence': 'SENSOR',
+      'silence.days': 'days',
+      'silence.mute_24h': 'Mute 24h',
+      'silence.mute_7d': 'Mute 7 days',
+      'silence.mute_recovery': 'Until new sensor',
+      'silence.muted_recovery': '🔕 Muted until the sensor returns',
+      'silence.muted_until': '🔕 Alerts muted until {0}',
+      'silence.no_data_since': 'No data for {0}',
+      'silence.unmute': 'Re-enable alerts',
       'config.note.test_emphasis': 'currently typed',
       'config.note.test_prefix': 'The test uses the values ',
       'config.note.test_suffix': ' in the form, even if they have not been saved yet.',

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -570,6 +570,49 @@
       white-space: nowrap;
     }
 
+    /* ── Sensor silence (no readings arriving) ─────────────────── */
+    .silence-badge {
+      display: inline-block;
+      padding: .22rem .6rem;
+      border-radius: 999px;
+      font-size: .72rem;
+      font-weight: 700;
+      white-space: nowrap;
+      color: var(--yellow-fg, #92600a);
+      background: color-mix(in oklab, var(--status-warn, #d97706) 14%, transparent);
+      border: 1px solid color-mix(in oklab, var(--status-warn, #d97706) 32%, transparent);
+    }
+    .silence-badge.muted { opacity: .65; }
+    .silence-controls {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: .5rem;
+      margin-top: .65rem;
+      padding: .55rem .7rem;
+      border-radius: .55rem;
+      background: color-mix(in oklab, var(--status-warn, #d97706) 8%, transparent);
+      border: 1px dashed color-mix(in oklab, var(--status-warn, #d97706) 30%, transparent);
+      font-size: .8rem;
+    }
+    .silence-controls-label { font-weight: 600; }
+    .silence-btn {
+      padding: .3rem .65rem;
+      border-radius: .5rem;
+      border: 1px solid var(--border, #d4c9bc);
+      background: var(--surface, #fff);
+      color: inherit;
+      font: inherit;
+      font-size: .76rem;
+      cursor: pointer;
+    }
+    .silence-btn:hover:not(:disabled) {
+      border-color: color-mix(in oklab, var(--status-warn, #d97706) 50%, var(--border, #d4c9bc));
+    }
+    .silence-btn:disabled { opacity: .5; cursor: wait; }
+    .silence-muted-note { font-weight: 600; opacity: .85; }
+    .senior-meta-value.silenced { color: var(--yellow-fg, #92600a); font-weight: 700; }
+
     /* ── Patient name ──────────────────────────────────────────── */
     .patient-name {
       font-weight: 600;
@@ -2318,7 +2361,9 @@
           arrow: arrowEl ? arrowEl.textContent.trim() : '',
           level: levelEl ? levelEl.textContent.trim() : '',
           trendAlert: trendAlertEl ? trendAlertEl.textContent.trim() : '',
-          time: timeEl ? timeEl.textContent.trim() : ''
+          time: timeEl ? timeEl.textContent.trim() : '',
+          silence: row.dataset.silence || null,
+          silenceHuman: row.dataset.silenceHuman || ''
         });
       });
 
@@ -2373,7 +2418,9 @@
           +     '</div>'
           +     '<div class="senior-meta-item">'
           +       '<span class="senior-meta-label">Última lectura</span>'
-          +       '<span class="senior-meta-value">' + escapeHtml(p.time || '—') + '</span>'
+          +       (p.silence
+                    ? '<span class="senior-meta-value silenced">📡 ' + escapeHtml(p.silenceHuman || p.time || '—') + (p.silence === 'muted' ? ' 🔕' : '') + '</span>'
+                    : '<span class="senior-meta-value">' + escapeHtml(p.time || '—') + '</span>')
           +     '</div>'
           +   '</div>'
           + '</article>';
@@ -2480,6 +2527,7 @@
     if (level === 'low')  return i18n.t('alert_level.low');
     if (level === 'high') return i18n.t('alert_level.high');
     if (level.startsWith('trend_')) return i18n.t('alert_level.trend');
+    if (level.startsWith('silence_')) return i18n.t('alert_level.silence');
     return level.toUpperCase();
   }
 
@@ -2487,6 +2535,35 @@
     if (level === 'low')  return 'alert-low';
     if (level === 'high') return 'alert-high';
     return 'alert-trend';
+  }
+
+  // ── Sensor silence helpers ─────────────────────────────────────────────────
+
+  function silenceInfo(p) {
+    var s = p.silence || {};
+    if (!s.enabled || s.minutes == null) return { active: false, muted: false, minutes: null, mutedUntil: null };
+    var muted = !!s.muted_until
+      && (s.muted_until === 'recovery' || new Date(s.muted_until) > new Date());
+    return {
+      active: s.minutes >= (s.check_after_minutes || 60),
+      muted: muted,
+      minutes: s.minutes,
+      mutedUntil: s.muted_until || null,
+    };
+  }
+
+  function silenceHuman(minutes) {
+    if (minutes < 120) return Math.floor(minutes) + ' min';
+    var h = Math.floor(minutes / 60);
+    if (h < 48) return h + 'h';
+    return Math.floor(h / 24) + ' ' + i18n.t('silence.days');
+  }
+
+  function silenceMutedLabel(mutedUntil) {
+    if (mutedUntil === 'recovery') return i18n.t('silence.muted_recovery');
+    var d = new Date(mutedUntil);
+    var txt = isNaN(d) ? mutedUntil : d.toLocaleString(undefined, { day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit' });
+    return i18n.t('silence.muted_until', txt);
   }
 
   function trendArrowHtml(arrow, trendName) {
@@ -2881,15 +2958,19 @@ if (!isNaN(cg) && cg > 0) {
       const timeSince     = formatTimeSince(p.fetched_at || p.timestamp);
       const glucoseClass  = getGlucoseTrendClass(p.trend_alert);
       const pid           = escapeHtml(String(p.patient_id));
+      const sil           = silenceInfo(p);
+      const silHuman      = sil.active ? silenceHuman(sil.minutes) : '';
 
-      // Auto-expand for alert states; preserve manual expansion for normal rows
-      const isExpanded    = isAlertRowClass(rowClass) || manuallyExpanded.has(String(p.patient_id));
+      // Auto-expand for alert states or active silence; preserve manual expansion
+      const isExpanded    = isAlertRowClass(rowClass) || (sil.active && !sil.muted)
+                            || manuallyExpanded.has(String(p.patient_id));
 
       const glucoseStr    = String(glucose);
 
       return `
         <tr class="patient-row ${rowClass}${isExpanded ? ' expanded' : ''}"
-            data-patient-id="${pid}" tabindex="0" role="button" aria-expanded="${isExpanded}">
+            data-patient-id="${pid}" tabindex="0" role="button" aria-expanded="${isExpanded}"
+            ${sil.active ? `data-silence="${sil.muted ? 'muted' : 'active'}" data-silence-human="${escapeHtml(silHuman)}"` : ''}>
           <td class="patient-name">${name}</td>
           <td>
             <span class="glucose-display">
@@ -2900,7 +2981,9 @@ if (!isNaN(cg) && cg > 0) {
           <td>${arrowHtml}</td>
           <td><span class="level-badge">${escapeHtml(level)}</span></td>
           <td class="trend-alert-text col-trend-alert">${trendAlert}</td>
-          <td class="time-text">${escapeHtml(timeSince)}</td>
+          <td class="time-text">${sil.active
+            ? `<span class="silence-badge${sil.muted ? ' muted' : ''}">📡 ${escapeHtml(silHuman)}${sil.muted ? ' 🔕' : ''}</span>`
+            : escapeHtml(timeSince)}</td>
         </tr>
         <tr class="expanded-details-row${isExpanded ? ' visible' : ''}" data-patient-id="${pid}">
           <td colspan="6">
@@ -2929,6 +3012,16 @@ if (!isNaN(cg) && cg > 0) {
                   ? `<span aria-hidden="true">📊</span> <span>${i18n.t('card.trend_prefix')}${trendAlert}</span>`
                   : `<span aria-hidden="true">✅</span> <span>${i18n.t('card.stable_trend')}</span>`}
               </p>
+              ${sil.active ? `
+              <div class="silence-controls" data-patient-id="${pid}">
+                <span class="silence-controls-label">📡 ${i18n.t('silence.no_data_since', escapeHtml(silHuman))}</span>
+                ${sil.muted
+                  ? `<span class="silence-muted-note">${escapeHtml(silenceMutedLabel(sil.mutedUntil))}</span>
+                     <button type="button" class="silence-btn silence-unmute-btn" data-pid="${pid}">${i18n.t('silence.unmute')}</button>`
+                  : `<button type="button" class="silence-btn" data-pid="${pid}" data-duration="24h">🔕 ${i18n.t('silence.mute_24h')}</button>
+                     <button type="button" class="silence-btn" data-pid="${pid}" data-duration="7d">🔕 ${i18n.t('silence.mute_7d')}</button>
+                     <button type="button" class="silence-btn" data-pid="${pid}" data-duration="recovery">🔕 ${i18n.t('silence.mute_recovery')}</button>`}
+              </div>` : ''}
             </div>
           </td>
         </tr>`;
@@ -2939,6 +3032,31 @@ if (!isNaN(cg) && cg > 0) {
       row.addEventListener('click',   ()  => _toggleExpanded(row));
       row.addEventListener('keydown', (e) => {
         if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); _toggleExpanded(row); }
+      });
+    });
+
+    // Silence mute/unmute buttons (caregiver snooze)
+    tbody.querySelectorAll('.silence-btn').forEach(btn => {
+      btn.addEventListener('click', async (e) => {
+        e.stopPropagation();
+        const pid = btn.dataset.pid;
+        const isUnmute = btn.classList.contains('silence-unmute-btn');
+        const action = isUnmute ? 'unmute' : 'mute';
+        // Cookie read kept inline: getCsrfToken() lives in the push IIFE scope.
+        const csrf = (document.cookie.split('; ').find(r => r.startsWith('csrf_token=')) || '').split('=')[1] || '';
+        btn.disabled = true;
+        try {
+          const resp = await fetch(`/api/patients/${encodeURIComponent(pid)}/silence/${action}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': csrf },
+            body: isUnmute ? '{}' : JSON.stringify({ duration: btn.dataset.duration }),
+          });
+          if (!resp.ok) throw new Error('HTTP ' + resp.status);
+          await fetchPatients();   // re-render with the new mute state
+        } catch (err) {
+          console.error('silence ' + action + ' failed', err);
+          btn.disabled = false;
+        }
       });
     });
 

--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,16 @@ import yaml
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
-from src.alert_engine import build_message, evaluate, evaluate_trend, is_stale, should_alert
+from src.alert_engine import (
+    build_message,
+    build_silence_message,
+    evaluate,
+    evaluate_silence,
+    evaluate_trend,
+    is_stale,
+    should_alert,
+    silence_minutes,
+)
 from src.alert_history import cleanup_old_alerts, init_db, log_alert
 from src.bootstrap import BootstrapError, bootstrap_storage
 from src.config_schema import validate_config as schema_validate_config
@@ -154,12 +163,54 @@ def run_once(
         timestamp = reading["timestamp"]
         trend_arrow = reading["trend_arrow"]
         logger.info("  %s: %d mg/dL %s (%s)", patient_name, glucose_value, trend_arrow, timestamp)
+        patient_state = get_patient_state(state, patient_id)
         if is_stale(timestamp, max_age):
-            logger.warning("  Stale reading for %s from %s, skipping", patient_name, timestamp)
+            # Silence is an event, not an absence: escalate instead of
+            # skipping quietly (sensor expired, phone away, sensor failed).
+            silence_state = patient_state.get("silence", {})
+            action = evaluate_silence(timestamp, silence_state, config)
+            if action and notifier:
+                minutes = silence_minutes(timestamp)
+                message = build_silence_message(action, patient_name, minutes, config)
+                if notifier.notify(message, glucose_value, f"silence_{action}"):
+                    new_silence = dict(silence_state)
+                    new_silence["stage"] = (
+                        "stage2" if action in ("stage2", "reminder") else "stage1"
+                    )
+                    new_silence["last_alert_time"] = datetime.now(timezone.utc).isoformat()
+                    patient_state = dict(patient_state)
+                    patient_state["silence"] = new_silence
+                    state = set_patient_state(state, patient_id, patient_state)
+                    state_changed = True
+                    log_alert(
+                        db_path, patient_id, patient_name, glucose_value,
+                        f"silence_{action}", trend_arrow, message,
+                    )
+                    logger.info("  Silence alert (%s) sent for %s: %s", action, patient_name, message)
+                else:
+                    logger.error("  All outputs failed for silence alert (%s)", patient_name)
+            else:
+                logger.warning("  Stale reading for %s from %s, skipping", patient_name, timestamp)
             continue
+        # Fresh reading: if we had flagged this patient as silent, notify
+        # recovery and clear the silence sub-state (including any mute).
+        silence_state = patient_state.get("silence")
+        if silence_state:
+            if silence_state.get("stage") and notifier:
+                message = build_silence_message(
+                    "recovered", patient_name, 0, config,
+                    glucose_value=glucose_value, trend_arrow=trend_arrow,
+                )
+                notifier.notify(message, glucose_value, "silence_recovered")
+                logger.info("  Silence recovered for %s", patient_name)
+            patient_state = {k: v for k, v in patient_state.items() if k != "silence"}
+            if patient_state:
+                state = set_patient_state(state, patient_id, patient_state)
+            else:
+                state = clear_patient_state(state, patient_id)
+            state_changed = True
         level = evaluate(glucose_value, config)
         trend_alert = evaluate_trend(glucose_value, trend_arrow, config)
-        patient_state = get_patient_state(state, patient_id)
         if level == "normal" and trend_alert == "normal":
             if patient_state:
                 state = clear_patient_state(state, patient_id)

--- a/src/main.py
+++ b/src/main.py
@@ -37,8 +37,10 @@ from src.state import (
     clear_patient_state,
     get_patient_state,
     load_state,
+    merge_silence_mutes,
     save_state,
     set_patient_state,
+    state_lock,
 )
 
 logger = logging.getLogger("family-glucose-monitor")
@@ -249,7 +251,12 @@ def run_once(
         else:
             logger.error("  All outputs failed for %s, state not updated", patient_name)
     if state_changed:
-        save_state(state_path, state)
+        # Serialise against the dashboard's mute endpoints and graft any
+        # mute written mid-cycle so it survives this save: the in-memory
+        # copy was loaded at cycle start and would otherwise clobber it.
+        with state_lock(state_path):
+            state = merge_silence_mutes(state, load_state(state_path))
+            save_state(state_path, state)
 
     max_days = config.get("alert_history_max_days", 7)
     cleanup_old_alerts(db_path, max_days)

--- a/src/outputs/webpush.py
+++ b/src/outputs/webpush.py
@@ -200,5 +200,10 @@ def _title_for_level(level: str) -> str:
         "trend_falling": "📉 Glucosa bajando",
         "trend_rising_fast": "📈 Glucosa subiendo rápido",
         "trend_rising": "📈 Glucosa subiendo",
+        # Sensor-silence alerts (readings stopped arriving).
+        "silence_stage1": "📡 Sensor sin reportar",
+        "silence_stage2": "📡 Sensor en silencio",
+        "silence_reminder": "📡 Sensor sigue sin reportar",
+        "silence_recovered": "🟢 Sensor reportando de nuevo",
     }
     return mapping.get(level, "🔔 Alerta de glucosa")

--- a/src/state.py
+++ b/src/state.py
@@ -2,6 +2,56 @@
 import json
 import os
 import tempfile
+from contextlib import contextmanager
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows
+    fcntl = None
+
+
+@contextmanager
+def state_lock(path: str):
+    """Advisory file lock serialising state.json writers.
+
+    In ``full`` mode the polling thread (run_once) and the dashboard's mute
+    endpoints write the same state file from different threads/processes
+    with a load→mutate→save pattern; this lock makes each writer's sequence
+    atomic. Best-effort no-op on platforms without ``fcntl`` (Windows).
+    """
+    lock_file = None
+    try:
+        if fcntl is not None:
+            lock_file = open(path + ".lock", "w")
+            fcntl.flock(lock_file, fcntl.LOCK_EX)
+        yield
+    finally:
+        if lock_file is not None:
+            try:
+                fcntl.flock(lock_file, fcntl.LOCK_UN)
+            except OSError:
+                pass
+            lock_file.close()
+
+
+def merge_silence_mutes(state: dict, disk_state: dict) -> dict:
+    """Graft silence mutes from *disk_state* into *state* (mutes win).
+
+    The monitor holds its in-memory copy of the state for a whole polling
+    cycle; a caregiver mute saved by the dashboard meanwhile would be
+    clobbered on save. Before persisting, any ``silence.muted_until`` found
+    on disk and absent in the in-memory copy is preserved.
+    """
+    for pid, patient_state in disk_state.items():
+        if not isinstance(patient_state, dict):
+            continue
+        muted_until = (patient_state.get("silence") or {}).get("muted_until")
+        if not muted_until:
+            continue
+        target = state.setdefault(pid, {})
+        silence = target.setdefault("silence", {})
+        silence.setdefault("muted_until", muted_until)
+    return state
 
 
 def load_state(path: str) -> dict:

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -688,3 +688,17 @@ def test_silence_enabled_non_bool_rejected():
     cfg["alerts"]["silence"] = {"enabled": "yes"}
     errors = validate_config(cfg)
     assert any("silence.enabled" in e for e in errors)
+
+
+def test_silence_explicit_null_rejected():
+    cfg = _valid_config()
+    cfg["alerts"]["silence"] = {"check_after_minutes": None}
+    errors = validate_config(cfg)
+    assert any("check_after_minutes" in e for e in errors)
+
+
+def test_silence_bool_rejected():
+    cfg = _valid_config()
+    cfg["alerts"]["silence"] = {"ask_after_minutes": True}
+    errors = validate_config(cfg)
+    assert any("ask_after_minutes" in e for e in errors)

--- a/tests/test_config_schema.py
+++ b/tests/test_config_schema.py
@@ -655,3 +655,36 @@ def test_reading_history_max_days_non_int_rejected():
     cfg["reading_history_max_days"] = "90"
     errors = validate_config(cfg)
     assert any("reading_history_max_days" in e for e in errors)
+
+
+# -- alerts.silence --
+
+def test_silence_section_valid():
+    cfg = _valid_config()
+    cfg["alerts"]["silence"] = {
+        "enabled": True, "check_after_minutes": 60,
+        "ask_after_minutes": 180, "remind_every_hours": 24,
+        "messages": {"stage1": "hola {patient_name}"},
+    }
+    assert validate_config(cfg) == []
+
+
+def test_silence_ask_must_exceed_check():
+    cfg = _valid_config()
+    cfg["alerts"]["silence"] = {"check_after_minutes": 180, "ask_after_minutes": 60}
+    errors = validate_config(cfg)
+    assert any("ask_after_minutes" in e for e in errors)
+
+
+def test_silence_negative_rejected():
+    cfg = _valid_config()
+    cfg["alerts"]["silence"] = {"check_after_minutes": -5}
+    errors = validate_config(cfg)
+    assert any("check_after_minutes" in e for e in errors)
+
+
+def test_silence_enabled_non_bool_rejected():
+    cfg = _valid_config()
+    cfg["alerts"]["silence"] = {"enabled": "yes"}
+    errors = validate_config(cfg)
+    assert any("silence.enabled" in e for e in errors)

--- a/tests/test_run_once.py
+++ b/tests/test_run_once.py
@@ -86,8 +86,13 @@ def test_no_readings_returns_early():
 # ---------------------------------------------------------------------------
 
 def test_stale_reading_is_skipped():
-    """A stale reading does not trigger an alert or state change."""
-    reading = _stale_reading(glucose=50)  # low but stale
+    """A stale reading below the silence threshold triggers nothing.
+
+    30 min: stale (> max_reading_age_minutes=15) but below the silence
+    check threshold (60 min), so neither a glucose alert nor a silence
+    alert fires.
+    """
+    reading = _fresh_reading(glucose=50, age_seconds=1800)  # low but stale
 
     mock_output = _MockOutput(success=True)
 
@@ -109,8 +114,9 @@ def test_stale_reading_is_skipped():
 
 
 def test_stale_reading_does_not_clear_existing_state():
-    """A stale reading for a patient in alert state does not clear that state."""
-    reading = _stale_reading(glucose=50, patient_id="p1")
+    """A stale reading (below silence threshold) for a patient in alert state
+    does not clear that state."""
+    reading = _fresh_reading(glucose=50, patient_id="p1", age_seconds=1800)
     existing_state = {
         "p1": {
             "last_alert_time": datetime.now(timezone.utc).isoformat(),
@@ -604,3 +610,147 @@ def test_trend_only_alert_passes_effective_level_to_outputs():
 
     mock_output.send_alert.assert_called_once()
     assert mock_output.send_alert.call_args[0][2] == "trend_falling_fast"
+
+
+# ---------------------------------------------------------------------------
+# Sensor-silence alerts (escalation + recovery + mute)
+# ---------------------------------------------------------------------------
+
+def _silence_patches(mock_output, state=None):
+    """Common patch set for silence tests."""
+    return (
+        patch("src.main.init_db"),
+        patch("src.main.load_state", return_value=state if state is not None else {}),
+        patch("src.main.save_state"),
+        patch("src.main.read_all_patients"),
+        patch("src.main._save_readings_cache"),
+        patch("src.main.log_alert"),
+        patch("src.main.cleanup_old_alerts"),
+        patch("src.main.cleanup_old_readings"),
+        patch("src.main.build_outputs", return_value=[mock_output]),
+    )
+
+
+def test_silence_stage1_at_90_minutes():
+    """90 min of silence fires the stage1 check notice."""
+    reading = _fresh_reading(glucose=120, patient_id="p1", age_seconds=90 * 60)
+    mock_output = _MockOutput(success=True)
+
+    with (
+        patch("src.main.init_db"),
+        patch("src.main.load_state", return_value={}),
+        patch("src.main.save_state") as mock_save,
+        patch("src.main.read_all_patients", return_value=[reading]),
+        patch("src.main._save_readings_cache"),
+        patch("src.main.log_alert") as mock_log,
+        patch("src.main.cleanup_old_alerts"),
+        patch("src.main.cleanup_old_readings"),
+        patch("src.main.build_outputs", return_value=[mock_output]),
+    ):
+        run_once(_config())
+
+    mock_output.send_alert.assert_called_once()
+    assert mock_output.send_alert.call_args[0][2] == "silence_stage1"
+    assert "revisa que el teléfono" in mock_output.send_alert.call_args[0][0]
+    mock_log.assert_called_once()
+    saved = mock_save.call_args[0][1]
+    assert saved["p1"]["silence"]["stage"] == "stage1"
+
+
+def test_silence_stage2_directly_after_26_hours():
+    """First evaluation after 26h jumps straight to stage2 with approved wording."""
+    reading = _fresh_reading(glucose=120, patient_id="p1", age_seconds=26 * 3600)
+    mock_output = _MockOutput(success=True)
+
+    with (
+        patch("src.main.init_db"),
+        patch("src.main.load_state", return_value={}),
+        patch("src.main.save_state") as mock_save,
+        patch("src.main.read_all_patients", return_value=[reading]),
+        patch("src.main._save_readings_cache"),
+        patch("src.main.log_alert"),
+        patch("src.main.cleanup_old_alerts"),
+        patch("src.main.cleanup_old_readings"),
+        patch("src.main.build_outputs", return_value=[mock_output]),
+    ):
+        run_once(_config())
+
+    assert mock_output.send_alert.call_args[0][2] == "silence_stage2"
+    assert "el sensor terminó su vida útil" in mock_output.send_alert.call_args[0][0]
+    assert mock_save.call_args[0][1]["p1"]["silence"]["stage"] == "stage2"
+
+
+def test_silence_muted_suppresses_alert():
+    """A future muted_until suppresses silence alerts entirely."""
+    from datetime import datetime as _dt
+    reading = _fresh_reading(glucose=120, patient_id="p1", age_seconds=26 * 3600)
+    future = (_dt.now(timezone.utc) + timedelta(days=1)).isoformat()
+    state = {"p1": {"silence": {"stage": "stage2", "muted_until": future,
+                                "last_alert_time": (_dt.now(timezone.utc) - timedelta(days=2)).isoformat()}}}
+    mock_output = _MockOutput(success=True)
+
+    with (
+        patch("src.main.init_db"),
+        patch("src.main.load_state", return_value=copy.deepcopy(state)),
+        patch("src.main.save_state") as mock_save,
+        patch("src.main.read_all_patients", return_value=[reading]),
+        patch("src.main._save_readings_cache"),
+        patch("src.main.log_alert"),
+        patch("src.main.cleanup_old_alerts"),
+        patch("src.main.cleanup_old_readings"),
+        patch("src.main.build_outputs", return_value=[mock_output]),
+    ):
+        run_once(_config())
+
+    mock_output.send_alert.assert_not_called()
+    mock_save.assert_not_called()
+
+
+def test_silence_recovery_notifies_and_clears():
+    """Fresh reading after alerted silence: recovery notice + silence cleared."""
+    reading = _fresh_reading(glucose=120, patient_id="p1")  # fresh, normal
+    state = {"p1": {"silence": {"stage": "stage2", "muted_until": "recovery",
+                                "last_alert_time": datetime.now(timezone.utc).isoformat()}}}
+    mock_output = _MockOutput(success=True)
+
+    with (
+        patch("src.main.init_db"),
+        patch("src.main.load_state", return_value=copy.deepcopy(state)),
+        patch("src.main.save_state") as mock_save,
+        patch("src.main.read_all_patients", return_value=[reading]),
+        patch("src.main._save_readings_cache"),
+        patch("src.main.log_alert"),
+        patch("src.main.cleanup_old_alerts"),
+        patch("src.main.cleanup_old_readings"),
+        patch("src.main.build_outputs", return_value=[mock_output]),
+    ):
+        run_once(_config())
+
+    mock_output.send_alert.assert_called_once()
+    assert mock_output.send_alert.call_args[0][2] == "silence_recovered"
+    assert "reportando de nuevo" in mock_output.send_alert.call_args[0][0]
+    saved = mock_save.call_args[0][1]
+    assert "silence" not in saved.get("p1", {})  # cleared (or whole patient gone)
+
+
+def test_silence_mute_only_cleared_without_notification():
+    """Proactive mute (no stage) + fresh reading: clear silently, no message."""
+    reading = _fresh_reading(glucose=120, patient_id="p1")
+    state = {"p1": {"silence": {"muted_until": "recovery"}}}
+    mock_output = _MockOutput(success=True)
+
+    with (
+        patch("src.main.init_db"),
+        patch("src.main.load_state", return_value=copy.deepcopy(state)),
+        patch("src.main.save_state") as mock_save,
+        patch("src.main.read_all_patients", return_value=[reading]),
+        patch("src.main._save_readings_cache"),
+        patch("src.main.log_alert"),
+        patch("src.main.cleanup_old_alerts"),
+        patch("src.main.cleanup_old_readings"),
+        patch("src.main.build_outputs", return_value=[mock_output]),
+    ):
+        run_once(_config())
+
+    mock_output.send_alert.assert_not_called()
+    mock_save.assert_called_once()  # state cleaned

--- a/tests/test_run_once.py
+++ b/tests/test_run_once.py
@@ -754,3 +754,30 @@ def test_silence_mute_only_cleared_without_notification():
 
     mock_output.send_alert.assert_not_called()
     mock_save.assert_called_once()  # state cleaned
+
+
+def test_mid_cycle_mute_survives_state_save():
+    """A mute written to disk while run_once holds its copy is preserved on save."""
+    reading = _fresh_reading(glucose=55, patient_id="p1")  # low → alert → save
+
+    mock_output = _MockOutput(success=True)
+    disk_with_mute = {"p2": {"silence": {"muted_until": "recovery"}}}
+
+    with (
+        patch("src.main.init_db"),
+        # First load (cycle start) sees no mute; second load (inside the
+        # locked save) sees the mute the dashboard wrote mid-cycle.
+        patch("src.main.load_state", side_effect=[{}, copy.deepcopy(disk_with_mute)]),
+        patch("src.main.save_state") as mock_save,
+        patch("src.main.read_all_patients", return_value=[reading]),
+        patch("src.main._save_readings_cache"),
+        patch("src.main.log_alert"),
+        patch("src.main.cleanup_old_alerts"),
+        patch("src.main.cleanup_old_readings"),
+        patch("src.main.build_outputs", return_value=[mock_output]),
+    ):
+        run_once(_config())
+
+    saved = mock_save.call_args[0][1]
+    assert saved["p2"]["silence"]["muted_until"] == "recovery"  # mute preserved
+    assert saved["p1"]["last_alert_level"] == "low"             # alert state kept

--- a/tests/test_silence_alerts.py
+++ b/tests/test_silence_alerts.py
@@ -145,3 +145,42 @@ def test_template_injection_blocked():
     cfg = {"alerts": {"silence": {"messages": {"stage1": "{patient_name.__class__}"}}}}
     msg = build_silence_message("stage1", "Ana", 75, config=cfg)
     assert "__class__" in msg  # returned raw, not evaluated
+
+
+# ── Review fixes (PR #96): null/bool config, mute merge ─────────────────────
+
+
+def test_explicit_null_does_not_override_default():
+    """A YAML `null` must not clobber the runtime default (would crash compares)."""
+    cfg = {"alerts": {"silence": {"check_after_minutes": None}}}
+    merged = get_silence_config(cfg)
+    assert merged["check_after_minutes"] == 60
+    # And evaluate_silence keeps working
+    assert evaluate_silence(_ts(90), {}, config=cfg, now=NOW) == "stage1"
+
+
+def test_merge_silence_mutes_preserves_disk_mute():
+    from src.state import merge_silence_mutes
+
+    in_memory = {"p1": {"silence": {"stage": "stage2", "last_alert_time": "x"}}}
+    disk = {"p1": {"silence": {"stage": "stage2", "muted_until": "recovery"}}}
+    merged = merge_silence_mutes(in_memory, disk)
+    assert merged["p1"]["silence"]["muted_until"] == "recovery"
+    assert merged["p1"]["silence"]["stage"] == "stage2"
+
+
+def test_merge_silence_mutes_does_not_resurrect_removed_patients():
+    from src.state import merge_silence_mutes
+
+    in_memory = {}
+    disk = {"p1": {"last_alert_level": "low"}}  # no mute → nothing grafted
+    assert merge_silence_mutes(in_memory, disk) == {}
+
+
+def test_merge_silence_mutes_in_memory_mute_wins():
+    from src.state import merge_silence_mutes
+
+    in_memory = {"p1": {"silence": {"muted_until": "2026-07-01T00:00:00+00:00"}}}
+    disk = {"p1": {"silence": {"muted_until": "recovery"}}}
+    merged = merge_silence_mutes(in_memory, disk)
+    assert merged["p1"]["silence"]["muted_until"] == "2026-07-01T00:00:00+00:00"

--- a/tests/test_silence_alerts.py
+++ b/tests/test_silence_alerts.py
@@ -1,0 +1,147 @@
+"""Tests for the sensor-silence alert engine (src/alert_engine.py)."""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from src.alert_engine import (
+    build_silence_message,
+    evaluate_silence,
+    get_silence_config,
+    humanize_minutes,
+    is_silence_muted,
+    silence_minutes,
+)
+
+NOW = datetime(2026, 6, 5, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _ts(minutes_ago: float) -> datetime:
+    return NOW - timedelta(minutes=minutes_ago)
+
+
+# ── get_silence_config ───────────────────────────────────────────────────────
+
+
+def test_defaults_when_no_config():
+    cfg = get_silence_config(None)
+    assert cfg["enabled"] is True
+    assert cfg["check_after_minutes"] == 60
+    assert cfg["ask_after_minutes"] == 180
+    assert cfg["remind_every_hours"] == 24
+
+
+def test_config_overrides_defaults():
+    cfg = get_silence_config(
+        {"alerts": {"silence": {"check_after_minutes": 30, "enabled": False}}}
+    )
+    assert cfg["check_after_minutes"] == 30
+    assert cfg["enabled"] is False
+    assert cfg["ask_after_minutes"] == 180  # untouched default
+
+
+# ── evaluate_silence: stage transitions ──────────────────────────────────────
+
+
+def test_fresh_reading_no_action():
+    assert evaluate_silence(_ts(5), {}, now=NOW) is None
+
+
+def test_below_check_threshold_no_action():
+    assert evaluate_silence(_ts(59), {}, now=NOW) is None
+
+
+def test_stage1_at_check_threshold():
+    assert evaluate_silence(_ts(61), {}, now=NOW) == "stage1"
+
+
+def test_stage1_not_repeated():
+    state = {"stage": "stage1", "last_alert_time": _ts(30).isoformat()}
+    assert evaluate_silence(_ts(90), state, now=NOW) is None
+
+
+def test_stage2_at_ask_threshold():
+    state = {"stage": "stage1", "last_alert_time": _ts(120).isoformat()}
+    assert evaluate_silence(_ts(181), state, now=NOW) == "stage2"
+
+
+def test_stage2_directly_when_first_seen_late():
+    """First evaluation after 3h+ jumps straight to stage2 (no redundant stage1)."""
+    assert evaluate_silence(_ts(200), {}, now=NOW) == "stage2"
+
+
+def test_reminder_after_24h():
+    state = {"stage": "stage2", "last_alert_time": (NOW - timedelta(hours=25)).isoformat()}
+    assert evaluate_silence(_ts(60 * 30), state, now=NOW) == "reminder"
+
+
+def test_no_reminder_before_24h():
+    state = {"stage": "stage2", "last_alert_time": (NOW - timedelta(hours=23)).isoformat()}
+    assert evaluate_silence(_ts(60 * 30), state, now=NOW) is None
+
+
+def test_disabled_silences_everything():
+    cfg = {"alerts": {"silence": {"enabled": False}}}
+    assert evaluate_silence(_ts(60 * 24 * 5), {}, config=cfg, now=NOW) is None
+
+
+# ── mute ─────────────────────────────────────────────────────────────────────
+
+
+def test_mute_until_future_suppresses():
+    state = {"stage": "stage2", "muted_until": (NOW + timedelta(days=1)).isoformat()}
+    assert evaluate_silence(_ts(60 * 30), state, now=NOW) is None
+
+
+def test_mute_expired_resumes():
+    state = {"stage": "stage2",
+             "muted_until": (NOW - timedelta(hours=1)).isoformat(),
+             "last_alert_time": (NOW - timedelta(hours=30)).isoformat()}
+    assert evaluate_silence(_ts(60 * 30), state, now=NOW) == "reminder"
+
+
+def test_mute_until_recovery_suppresses_indefinitely():
+    state = {"stage": "stage2", "muted_until": "recovery"}
+    assert evaluate_silence(_ts(60 * 24 * 30), state, now=NOW) is None
+
+
+def test_is_silence_muted_garbage_value():
+    assert is_silence_muted({"muted_until": "not-a-date"}, now=NOW) is False
+
+
+# ── helpers / messages ───────────────────────────────────────────────────────
+
+
+def test_silence_minutes():
+    assert silence_minutes(_ts(90), now=NOW) == pytest.approx(90)
+
+
+@pytest.mark.parametrize(
+    "minutes,expected",
+    [(45, "45 min"), (119, "119 min"), (180, "3h"), (60 * 47, "47h"), (60 * 72, "3 días")],
+)
+def test_humanize_minutes(minutes, expected):
+    assert humanize_minutes(minutes) == expected
+
+
+def test_stage2_message_wording():
+    """Exact wording approved: 'el sensor terminó su vida útil'."""
+    msg = build_silence_message("stage2", "Leticia", 185)
+    assert "el sensor terminó su vida útil" in msg
+    assert "Leticia" in msg
+    assert "3h" in msg
+
+
+def test_recovered_message_includes_reading():
+    msg = build_silence_message("recovered", "Mario", 0, glucose_value=98, trend_arrow="→")
+    assert "98" in msg and "→" in msg and "Mario" in msg
+
+
+def test_custom_template_from_config():
+    cfg = {"alerts": {"silence": {"messages": {"stage1": "ojo {patient_name} {silence_human}"}}}}
+    assert build_silence_message("stage1", "Ana", 75, config=cfg) == "ojo Ana 75 min"
+
+
+def test_template_injection_blocked():
+    cfg = {"alerts": {"silence": {"messages": {"stage1": "{patient_name.__class__}"}}}}
+    msg = build_silence_message("stage1", "Ana", 75, config=cfg)
+    assert "__class__" in msg  # returned raw, not evaluated

--- a/tests/test_silence_api.py
+++ b/tests/test_silence_api.py
@@ -1,0 +1,166 @@
+"""Tests for sensor-silence info in /api/patients and the mute endpoints."""
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+
+import src.api as api_module
+from src.api import app
+
+_MINIMAL_CONFIG = {
+    "api": {},
+    "alerts": {
+        "low_threshold": 70,
+        "high_threshold": 180,
+        "trend": {"enabled": False},
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def reset_state(monkeypatch):
+    monkeypatch.setattr(api_module, "_ALLOW_AUTH_DISABLED", True)
+    with api_module._cache_lock:
+        api_module._readings_cache.clear()
+    api_module._last_mtime = 0.0
+    yield
+    with api_module._cache_lock:
+        api_module._readings_cache.clear()
+    api_module._last_mtime = 0.0
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """Temp cache (one silent + one fresh patient) + temp state file."""
+    now = datetime.now(timezone.utc)
+    cache_file = tmp_path / "readings_cache.json"
+    cache_file.write_text(json.dumps({
+        "readings": [
+            {
+                "patient_id": "silent-1", "patient_name": "Leticia",
+                "value": 110, "trend_arrow": "→",
+                "timestamp": (now - timedelta(hours=26)).isoformat(),
+            },
+            {
+                "patient_id": "fresh-1", "patient_name": "Mario",
+                "value": 98, "trend_arrow": "→",
+                "timestamp": (now - timedelta(minutes=4)).isoformat(),
+            },
+        ],
+        "updated_at": now.isoformat(),
+    }))
+    state_file = tmp_path / "state.json"
+    config = dict(_MINIMAL_CONFIG)
+    config["api"] = {"cache_file": str(cache_file)}
+    config["state_file"] = str(state_file)
+    monkeypatch.setattr(api_module, "_config", config)
+    monkeypatch.setattr(api_module, "_reading_history", type(
+        "Stub", (), {"init_db": staticmethod(lambda *a, **k: None),
+                     "log_reading": staticmethod(lambda *a, **k: None)})())
+    return {"client": TestClient(app), "state_file": state_file, "tmp": tmp_path}
+
+
+# ── silence info attached to patient payloads ────────────────────────────────
+
+
+def test_patients_include_silence_info(env):
+    resp = env["client"].get("/api/patients")
+    assert resp.status_code == 200
+    by_id = {p["patient_id"]: p for p in resp.json()["patients"]}
+
+    silent = by_id["silent-1"]["silence"]
+    assert silent["enabled"] is True
+    assert silent["minutes"] >= 26 * 60 - 1
+    assert silent["check_after_minutes"] == 60
+    assert silent["ask_after_minutes"] == 180
+    assert silent["muted_until"] is None
+
+    fresh = by_id["fresh-1"]["silence"]
+    assert fresh["minutes"] < 60
+
+
+def test_single_patient_includes_silence(env):
+    resp = env["client"].get("/api/patients/silent-1")
+    assert resp.status_code == 200
+    assert resp.json()["silence"]["minutes"] >= 26 * 60 - 1
+
+
+def test_silence_reflects_state_stage_and_mute(env):
+    from src.state import save_state
+    save_state(str(env["state_file"]), {
+        "silent-1": {"silence": {"stage": "stage2", "muted_until": "recovery"}},
+    })
+    resp = env["client"].get("/api/patients/silent-1")
+    sil = resp.json()["silence"]
+    assert sil["stage"] == "stage2"
+    assert sil["muted_until"] == "recovery"
+
+
+# ── mute / unmute endpoints ──────────────────────────────────────────────────
+
+
+def test_mute_24h_writes_state(env):
+    resp = env["client"].post(
+        "/api/patients/silent-1/silence/mute", json={"duration": "24h"}
+    )
+    assert resp.status_code == 200
+    muted_until = resp.json()["muted_until"]
+    parsed = datetime.fromisoformat(muted_until)
+    assert parsed > datetime.now(timezone.utc) + timedelta(hours=23)
+
+    from src.state import load_state
+    state = load_state(str(env["state_file"]))
+    assert state["silent-1"]["silence"]["muted_until"] == muted_until
+
+
+def test_mute_recovery_literal(env):
+    resp = env["client"].post(
+        "/api/patients/silent-1/silence/mute", json={"duration": "recovery"}
+    )
+    assert resp.status_code == 200
+    assert resp.json()["muted_until"] == "recovery"
+
+
+def test_mute_invalid_duration_422(env):
+    resp = env["client"].post(
+        "/api/patients/silent-1/silence/mute", json={"duration": "forever"}
+    )
+    assert resp.status_code == 422
+
+
+def test_mute_unknown_patient_404(env):
+    resp = env["client"].post(
+        "/api/patients/nope/silence/mute", json={"duration": "24h"}
+    )
+    assert resp.status_code == 404
+
+
+def test_mute_preserves_existing_patient_state(env):
+    from src.state import load_state, save_state
+    save_state(str(env["state_file"]), {
+        "silent-1": {"last_alert_level": "low", "last_alert_time": "2026-06-01T00:00:00+00:00"},
+    })
+    env["client"].post("/api/patients/silent-1/silence/mute", json={"duration": "7d"})
+    state = load_state(str(env["state_file"]))
+    assert state["silent-1"]["last_alert_level"] == "low"  # untouched
+    assert "muted_until" in state["silent-1"]["silence"]
+
+
+def test_unmute_clears_mute_keeps_stage(env):
+    from src.state import load_state, save_state
+    save_state(str(env["state_file"]), {
+        "silent-1": {"silence": {"stage": "stage2", "muted_until": "recovery"}},
+    })
+    resp = env["client"].post("/api/patients/silent-1/silence/unmute")
+    assert resp.status_code == 200
+    state = load_state(str(env["state_file"]))
+    assert state["silent-1"]["silence"]["stage"] == "stage2"
+    assert "muted_until" not in state["silent-1"]["silence"]
+
+
+def test_unmute_when_nothing_muted_is_noop(env):
+    resp = env["client"].post("/api/patients/silent-1/silence/unmute")
+    assert resp.status_code == 200
+    from src.state import load_state
+    assert load_state(str(env["state_file"])) == {}

--- a/tests/test_silence_api.py
+++ b/tests/test_silence_api.py
@@ -160,7 +160,13 @@ def test_unmute_clears_mute_keeps_stage(env):
 
 
 def test_unmute_when_nothing_muted_is_noop(env):
+    """Idempotent unmute: 200 without touching state.json at all."""
     resp = env["client"].post("/api/patients/silent-1/silence/unmute")
     assert resp.status_code == 200
-    from src.state import load_state
-    assert load_state(str(env["state_file"])) == {}
+    assert resp.json()["muted_until"] is None
+    assert not env["state_file"].exists()  # no unnecessary write
+
+
+def test_unmute_unknown_patient_404(env):
+    resp = env["client"].post("/api/patients/nope/silence/unmute")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Resumen

Para un cuidador, **silencio y "todo bien" son indistinguibles** — y es justo el escenario peligroso (teléfono sin batería, sensor expirado o fallado). Hasta hoy el monitor saltaba las lecturas stale en silencio. Caso real que motivó la feature: dos sensores de la familia estuvieron fuera (uno por garantía, otro expirado) durante días y el sistema no avisó nada.

## Comportamiento

| Momento | Acción |
|---|---|
| 60 min sin lecturas | 📡 Aviso de revisión ("revisa que el teléfono esté cerca del sensor") |
| 3 h | ⚠️ Pregunta: "¿el sensor terminó su vida útil o se alejó del celular por un periodo prolongado?" |
| Cada 24 h mientras siga mudo | ⚠️ Recordatorio con duración acumulada |
| Al volver lecturas | 🟢 Aviso de recuperación con el valor actual — y limpia cualquier mute "hasta nuevo sensor" |

- Primera evaluación tardía salta directo a la etapa correcta (sin stage1 redundante).
- Configurable bajo `alerts.silence` (umbrales, mensajes con templates injection-safe, on/off). Habilitado por defecto.
- Alertas registradas en `alert_history` con nivel `silence_*`; web push con títulos propios.

## Snooze del cuidador (dashboard)

- Tarjeta del paciente: badge ámbar **📡 + duración** (vista moderna y senior); filas con silencio activo se auto-expanden.
- Panel expandido: **Silenciar 24h / 7 días / Hasta nuevo sensor** + estado de mute + reactivar.
- `POST /api/patients/{id}/silence/mute` (`24h|7d|recovery`) y `/unmute` — sesión + CSRF. El mute `recovery` se resuelve solo cuando el sensor de reemplazo reporta.
- El objeto `silence` de `/api/patients` se calcula **por request** — durante un silencio real el cache deja de cambiar, así que cualquier dato calculado en la recarga se congelaría exactamente cuando más importa.

## Tests y verificación

- Suite: **809 → 853 passing** (44 nuevos: motor puro, integración run_once, API mute, schema).
- Los 8 scripts inline de `index.html` pasan `node --check`.
- Smoke E2E con datos reales: 3 pacientes en silencio detectados (233 min / 27 h / 13 días), mute→GET refleja→unmute verificado.
- 2 tests existentes de stale ajustados de 1h→30min: con la feature, 1h de silencio ahora dispara stage1 **por diseño**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)