### PR TITLE
Security hardening: timing-safe CSRF, push endpoint allowlist, bind warning

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -23,6 +23,7 @@ port (configurable), has no authentication, and reads data from the
 ``timestamp``).  Both modules now share ``readings_cache.json`` as the single
 source of truth.
 """
+import hmac
 import json
 import logging
 import os
@@ -168,7 +169,7 @@ def _validate_csrf(request: Request) -> None:
 
     cookie_token = request.cookies.get(_CSRF_COOKIE)
     header_token = request.headers.get(_CSRF_HEADER)
-    if not cookie_token or not header_token or cookie_token != header_token:
+    if not cookie_token or not header_token or not hmac.compare_digest(cookie_token, header_token):
         raise HTTPException(status_code=403, detail="CSRF validation failed.")
 
 

--- a/src/api.py
+++ b/src/api.py
@@ -36,7 +36,6 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Literal, Optional
-from urllib.parse import urlparse as _urlparse
 
 import requests as _requests
 import yaml
@@ -907,32 +906,6 @@ def push_vapid_public_key():
     return {"publicKey": key}
 
 
-# Hosts of the browser push services we deliver to. A subscription endpoint
-# outside this list is either malformed or an attempt to point the server's
-# outgoing webpush POSTs at an arbitrary host (low-impact SSRF).
-_ALLOWED_PUSH_HOSTS = (
-    "fcm.googleapis.com",
-    "updates.push.services.mozilla.com",
-    "web.push.apple.com",
-)
-_ALLOWED_PUSH_HOST_SUFFIXES = (
-    ".notify.windows.com",
-    ".push.apple.com",
-)
-
-
-def _is_allowed_push_endpoint(url: str) -> bool:
-    """Return True if *url* is an https endpoint of a known push service."""
-    try:
-        parsed = _urlparse(url)
-    except ValueError:
-        return False
-    if parsed.scheme != "https" or not parsed.hostname:
-        return False
-    host = parsed.hostname.lower()
-    return host in _ALLOWED_PUSH_HOSTS or host.endswith(_ALLOWED_PUSH_HOST_SUFFIXES)
-
-
 @app.post("/api/push/subscribe", response_class=JSONResponse)
 async def push_subscribe(request: Request):
     """Save a browser push subscription from an authenticated user.
@@ -964,7 +937,7 @@ async def push_subscribe(request: Request):
             detail="endpoint, keys.p256dh y keys.auth son obligatorios",
         )
 
-    if not _is_allowed_push_endpoint(endpoint):
+    if not _push_subs.is_allowed_push_endpoint(endpoint):
         raise HTTPException(
             status_code=422,
             detail="endpoint debe ser https de un servicio de push conocido",

--- a/src/api.py
+++ b/src/api.py
@@ -36,6 +36,7 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Literal, Optional
+from urllib.parse import urlparse as _urlparse
 
 import requests as _requests
 import yaml
@@ -906,6 +907,32 @@ def push_vapid_public_key():
     return {"publicKey": key}
 
 
+# Hosts of the browser push services we deliver to. A subscription endpoint
+# outside this list is either malformed or an attempt to point the server's
+# outgoing webpush POSTs at an arbitrary host (low-impact SSRF).
+_ALLOWED_PUSH_HOSTS = (
+    "fcm.googleapis.com",
+    "updates.push.services.mozilla.com",
+    "web.push.apple.com",
+)
+_ALLOWED_PUSH_HOST_SUFFIXES = (
+    ".notify.windows.com",
+    ".push.apple.com",
+)
+
+
+def _is_allowed_push_endpoint(url: str) -> bool:
+    """Return True if *url* is an https endpoint of a known push service."""
+    try:
+        parsed = _urlparse(url)
+    except ValueError:
+        return False
+    if parsed.scheme != "https" or not parsed.hostname:
+        return False
+    host = parsed.hostname.lower()
+    return host in _ALLOWED_PUSH_HOSTS or host.endswith(_ALLOWED_PUSH_HOST_SUFFIXES)
+
+
 @app.post("/api/push/subscribe", response_class=JSONResponse)
 async def push_subscribe(request: Request):
     """Save a browser push subscription from an authenticated user.
@@ -935,6 +962,12 @@ async def push_subscribe(request: Request):
         raise HTTPException(
             status_code=422,
             detail="endpoint, keys.p256dh y keys.auth son obligatorios",
+        )
+
+    if not _is_allowed_push_endpoint(endpoint):
+        raise HTTPException(
+            status_code=422,
+            detail="endpoint debe ser https de un servicio de push conocido",
         )
 
     try:

--- a/src/main.py
+++ b/src/main.py
@@ -281,6 +281,12 @@ def _start_dashboard(config: dict) -> None:
     dash_cfg = config.get("dashboard", {})
     host = dash_cfg.get("host", "0.0.0.0")
     port = int(dash_cfg.get("port", 8080))
+    if host == "0.0.0.0":
+        logger.warning(
+            "Dashboard binding to 0.0.0.0 — reachable on ALL network interfaces. "
+            "Make sure a firewall, Tailscale, or reverse proxy restricts access, "
+            "or set dashboard.host to 127.0.0.1 in config.yaml."
+        )
     logger.info("Starting dashboard on http://%s:%d", host, port)
     uvicorn.run("src.api:app", host=host, port=port, log_level="info")
 

--- a/src/main.py
+++ b/src/main.py
@@ -281,11 +281,12 @@ def _start_dashboard(config: dict) -> None:
     dash_cfg = config.get("dashboard", {})
     host = dash_cfg.get("host", "0.0.0.0")
     port = int(dash_cfg.get("port", 8080))
-    if host == "0.0.0.0":
+    if host in ("0.0.0.0", "::", "[::]"):
         logger.warning(
-            "Dashboard binding to 0.0.0.0 — reachable on ALL network interfaces. "
+            "Dashboard binding to %s — reachable on ALL network interfaces. "
             "Make sure a firewall, Tailscale, or reverse proxy restricts access, "
-            "or set dashboard.host to 127.0.0.1 in config.yaml."
+            "or set dashboard.host to 127.0.0.1 in config.yaml.",
+            host,
         )
     logger.info("Starting dashboard on http://%s:%d", host, port)
     uvicorn.run("src.api:app", host=host, port=port, log_level="info")

--- a/src/outputs/webpush.py
+++ b/src/outputs/webpush.py
@@ -150,6 +150,16 @@ class WebPushOutput(BaseOutput):
         stale_endpoints: list[str] = []
 
         for sub in subscriptions:
+            # Subscriptions persisted before endpoint validation existed (or a
+            # tampered DB) may contain non-push-service URLs — never POST to
+            # them, and prune them like expired subscriptions.
+            if not _subs.is_allowed_push_endpoint(sub["endpoint"]):
+                logger.warning(
+                    "Push subscription endpoint not in allowlist, scheduling removal: %s…",
+                    sub["endpoint"][:40],
+                )
+                stale_endpoints.append(sub["endpoint"])
+                continue
             sub_info = {
                 "endpoint": sub["endpoint"],
                 "keys": {"p256dh": sub["p256dh"], "auth": sub["auth"]},

--- a/src/push_subscriptions.py
+++ b/src/push_subscriptions.py
@@ -23,6 +23,7 @@ Call :func:`init_db` once at startup with the database file path, then use
 import logging
 import time
 from typing import Optional
+from urllib.parse import urlparse
 
 from src.db import connect_db
 
@@ -30,6 +31,31 @@ logger = logging.getLogger(__name__)
 
 # Module-level path; set by init_db.
 _db_path: Optional[str] = None
+
+# Hosts of the browser push services we deliver to. A subscription endpoint
+# outside this list is either malformed or an attempt to point the server's
+# outgoing webpush POSTs at an arbitrary host (low-impact SSRF).
+ALLOWED_PUSH_HOSTS = (
+    "fcm.googleapis.com",
+    "updates.push.services.mozilla.com",
+    "web.push.apple.com",
+)
+ALLOWED_PUSH_HOST_SUFFIXES = (
+    ".notify.windows.com",
+    ".push.apple.com",
+)
+
+
+def is_allowed_push_endpoint(url: str) -> bool:
+    """Return True if *url* is an https endpoint of a known push service."""
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return False
+    if parsed.scheme != "https" or not parsed.hostname:
+        return False
+    host = parsed.hostname.lower()
+    return host in ALLOWED_PUSH_HOSTS or host.endswith(ALLOWED_PUSH_HOST_SUFFIXES)
 
 _DDL = """
 CREATE TABLE IF NOT EXISTS push_subscriptions (

--- a/tests/test_main_startup.py
+++ b/tests/test_main_startup.py
@@ -261,6 +261,11 @@ class TestBindAddressWarning:
         records = self._start_and_capture("0.0.0.0")
         assert any("0.0.0.0" in r.getMessage() for r in records)
 
+    @pytest.mark.parametrize("host", ["::", "[::]"])
+    def test_warns_on_ipv6_all_interfaces_bind(self, host):
+        records = self._start_and_capture(host)
+        assert any("ALL network interfaces" in r.getMessage() for r in records)
+
     def test_no_warning_on_loopback_bind(self):
         records = self._start_and_capture("127.0.0.1")
-        assert not [r for r in records if "0.0.0.0" in r.getMessage()]
+        assert not [r for r in records if "ALL network interfaces" in r.getMessage()]

--- a/tests/test_main_startup.py
+++ b/tests/test_main_startup.py
@@ -209,3 +209,58 @@ class TestNormalModeStartup:
             main_mod.main()
 
         assert setup_mode_calls == [], "Normal startup must not enter setup mode"
+
+
+# ---------------------------------------------------------------------------
+# Dashboard bind-address warning
+# ---------------------------------------------------------------------------
+
+class TestBindAddressWarning:
+    """_start_dashboard warns when binding to all interfaces.
+
+    Uses a direct capture handler on the module's own logger
+    ("family-glucose-monitor") instead of caplog because Alembic's
+    ``fileConfig(disable_existing_loggers=True)`` (run by the migration
+    tests in the same session) disables that logger, which caplog does
+    not re-enable. Same pattern as TestAcquireLockFcntlWarning in
+    test_startup.py.
+    """
+
+    def _start_and_capture(self, host):
+        import logging
+
+        import src.main as main_mod
+
+        captured: list[logging.LogRecord] = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                captured.append(record)
+
+        handler = _Capture(level=logging.WARNING)
+        target_logger = main_mod.logger
+        old_level = target_logger.level
+        old_disabled = target_logger.disabled
+        target_logger.addHandler(handler)
+        target_logger.disabled = False
+        if old_level == 0 or old_level > logging.WARNING:
+            target_logger.setLevel(logging.WARNING)
+        try:
+            config = {"dashboard": {"host": host, "port": 8080}}
+            fake_uvicorn = MagicMock()
+            with patch.dict(sys.modules, {"uvicorn": fake_uvicorn}):
+                main_mod._start_dashboard(config)
+            fake_uvicorn.run.assert_called_once()
+        finally:
+            target_logger.removeHandler(handler)
+            target_logger.setLevel(old_level)
+            target_logger.disabled = old_disabled
+        return captured
+
+    def test_warns_on_all_interfaces_bind(self):
+        records = self._start_and_capture("0.0.0.0")
+        assert any("0.0.0.0" in r.getMessage() for r in records)
+
+    def test_no_warning_on_loopback_bind(self):
+        records = self._start_and_capture("127.0.0.1")
+        assert not [r for r in records if "0.0.0.0" in r.getMessage()]

--- a/tests/test_push_notifications.py
+++ b/tests/test_push_notifications.py
@@ -119,6 +119,55 @@ class TestPushSubscribeEndpoint:
         resp = client.post("/api/push/subscribe", json=self._VALID_PAYLOAD)
         assert resp.status_code == 500
 
+    def _payload_with_endpoint(self, endpoint):
+        return {**self._VALID_PAYLOAD, "endpoint": endpoint}
+
+    def test_http_endpoint_returns_422(self, client):
+        resp = client.post(
+            "/api/push/subscribe",
+            json=self._payload_with_endpoint("http://fcm.googleapis.com/fcm/send/abc"),
+        )
+        assert resp.status_code == 422
+
+    def test_unknown_host_returns_422(self, client):
+        resp = client.post(
+            "/api/push/subscribe",
+            json=self._payload_with_endpoint("https://attacker.example.com/push"),
+        )
+        assert resp.status_code == 422
+
+    def test_host_suffix_spoof_returns_422(self, client):
+        """A host merely *containing* an allowed name must be rejected."""
+        resp = client.post(
+            "/api/push/subscribe",
+            json=self._payload_with_endpoint("https://fcm.googleapis.com.evil.example/send/abc"),
+        )
+        assert resp.status_code == 422
+
+    def test_malformed_url_returns_422(self, client):
+        resp = client.post(
+            "/api/push/subscribe",
+            json=self._payload_with_endpoint("not a url"),
+        )
+        assert resp.status_code == 422
+
+    @pytest.mark.parametrize(
+        "endpoint",
+        [
+            "https://fcm.googleapis.com/fcm/send/abc",
+            "https://updates.push.services.mozilla.com/wpush/v2/abc",
+            "https://web.push.apple.com/QAbc",
+            "https://es1.notify.windows.com/w/?token=abc",
+            "https://webpush.push.apple.com/QAbc",
+        ],
+    )
+    def test_known_push_services_return_200(self, client, endpoint):
+        resp = client.post(
+            "/api/push/subscribe",
+            json=self._payload_with_endpoint(endpoint),
+        )
+        assert resp.status_code == 200
+
 
 # ── POST /api/push/unsubscribe ───────────────────────────────────────────────
 

--- a/tests/test_push_notifications.py
+++ b/tests/test_push_notifications.py
@@ -224,6 +224,37 @@ class TestPushUnsubscribeEndpoint:
 
 
 # ---------------------------------------------------------------------------
+# send_alert — legacy/tampered endpoints outside the allowlist are never
+# POSTed to and get pruned (Copilot review on PR #97: the subscribe-time
+# allowlist alone does not cover rows persisted before the hardening).
+# ---------------------------------------------------------------------------
+
+class TestSendAlertEndpointFiltering:
+    _GOOD = "https://fcm.googleapis.com/fcm/send/good"
+    _BAD = "https://attacker.example.com/exfil"
+
+    def _output(self):
+        from src.outputs.webpush import WebPushOutput
+
+        return WebPushOutput(vapid_subject="mailto:test@example.com", icon_url="")
+
+    def test_disallowed_endpoint_is_not_posted_and_pruned(self):
+        push_subs_module.save_subscription(self._BAD, "p", "a")
+        push_subs_module.save_subscription(self._GOOD, "p", "a")
+        with (
+            patch("src.outputs.webpush.webpush") as mock_webpush,
+            patch("src.outputs.webpush._load_or_generate_vapid", return_value=("key", "pub")),
+        ):
+            self._output().send_alert("msg", 100, "low")
+        posted = [c.kwargs["subscription_info"]["endpoint"] for c in mock_webpush.call_args_list]
+        assert self._BAD not in posted
+        assert self._GOOD in posted
+        remaining = [s["endpoint"] for s in push_subs_module.get_all_subscriptions()]
+        assert self._BAD not in remaining
+        assert self._GOOD in remaining
+
+
+# ---------------------------------------------------------------------------
 # Notification titles for trend-only levels
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Resumen

Tres fixes de severidad baja de la auditoría 2026-06-04 (`AUDITORIA_2026-06-04.md`, items de seguridad):

1. **CSRF timing-safe** — `_validate_csrf` usaba `!=` para comparar tokens; ahora `hmac.compare_digest` (constant-time). Conducta idéntica: mismatch → 403. Cubierto por `TestCSRFProtection` existente.
2. **Allowlist de endpoints push** — `/api/push/subscribe` guardaba cualquier URL; `WebPushOutput` luego hace POST a ella en cada alerta (SSRF de bajo impacto). Ahora solo https hacia servicios push conocidos (FCM, Mozilla, Apple, Windows). 9 tests nuevos, incluyendo spoof por sufijo de host.
3. **Warning de bind 0.0.0.0** — `_start_dashboard` avisa una vez al arranque si se expone en todas las interfaces. El default NO cambia (prod sirve vía Tailscale). 2 tests nuevos con captura directa de logger (Alembic deshabilita loggers existentes en la misma sesión de tests — mismo patrón que `TestAcquireLockFcntlWarning`).

**Items de la auditoría verificados como YA NO aplicables** (sin cambios): fallback a password plaintext (schema exige PBKDF2), `migrations/env.py` (config correcta).

## Tests
Suite completa: **872 passed** (base 861).

🤖 Generated with [Claude Code](https://claude.com/claude-code)