### PR TITLE
fix(history): poller is the single writer of reading_history

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -69,13 +69,10 @@ _cache_lock = threading.Lock()
 _config: dict = {}
 _last_mtime: float = 0.0
 
-# Sensor timestamp of the last reading persisted to reading_history, per
-# patient — used to skip re-logging stale (unchanged) readings each poll.
-# In-memory on purpose: worst case after a restart is one duplicate row.
-# Guarded by its own lock so concurrent cache reloads can't both pass the
-# dedupe check and double-log the same reading.
-_last_logged_source_ts: dict = {}
-_last_logged_source_ts_lock = threading.Lock()
+# Reading history is written exclusively by the polling daemon (src/main.py),
+# which runs every cycle whether or not a dashboard client is connected. The
+# dashboard is a read-only consumer of reading_history.db, so a single writer
+# owns the file (no cross-process SQLite write contention).
 
 # External polling state — governed by main.py in 'full' mode.
 # Use a dedicated lock to avoid coupling with _cache_lock.
@@ -399,30 +396,9 @@ def _load_and_enrich_cache() -> None:
             _last_mtime = mtime
     logger.debug("Loaded %d readings from cache file", len(new_cache))
 
-    # Persist readings to history DB for sparkline time-series (best-effort).
-    # Deduplicated by the sensor's own timestamp: when a patient's reading is
-    # stale (sensor silent, phone away), every poll cycle re-delivers the same
-    # reading — logging it each time produced fake flat segments in the charts
-    # and inflated n_readings/TIR/CV in the history metrics.
-    if new_cache:
-        try:
-            rh_path = get_reading_history_db_path(_config)
-            _reading_history.init_db(rh_path)
-            for r in new_cache.values():
-                pid = r.get("patient_id", "")
-                pname = r.get("patient_name", pid)
-                gval = r.get("glucose_value") or r.get("value", 0)
-                if not pid or not gval:
-                    continue
-                source_ts = str(r.get("timestamp") or "")
-                with _last_logged_source_ts_lock:
-                    if source_ts and _last_logged_source_ts.get(pid) == source_ts:
-                        continue  # same sensor reading as the last one we logged
-                    _reading_history.log_reading(rh_path, pid, pname, int(gval))
-                    if source_ts:
-                        _last_logged_source_ts[pid] = source_ts
-        except Exception as exc:
-            logger.warning("Failed to persist readings to history DB: %s", exc)
+    # NOTE: reading history is no longer persisted here. The polling daemon
+    # (src/main.py) is the single writer and logs on every cycle, so history is
+    # captured continuously rather than only while a dashboard client is open.
 
 
 def _get_color(level: str, trend_alert: str) -> str:

--- a/src/main.py
+++ b/src/main.py
@@ -31,7 +31,11 @@ from src.outputs import build_outputs
 from src.outputs.base import Notifier
 from src.outputs.multi_notifier import MultiNotifier
 from src.paths import get_cache_path, get_db_path, get_reading_history_db_path, get_state_path
-from src.reading_history import cleanup_old_readings
+from src.reading_history import (
+    cleanup_old_readings,
+    init_db as init_reading_history_db,
+    log_reading_if_new,
+)
 from src.setup_status import check_setup
 from src.state import (
     clear_patient_state,
@@ -141,6 +145,9 @@ def run_once(
     db_path = get_db_path(config)
     init_db(db_path)
 
+    rh_path = get_reading_history_db_path(config)
+    init_reading_history_db(rh_path)
+
     state = load_state(state_path)
     readings = read_all_patients(config)
     if not readings:
@@ -165,6 +172,15 @@ def run_once(
         timestamp = reading["timestamp"]
         trend_arrow = reading["trend_arrow"]
         logger.info("  %s: %d mg/dL %s (%s)", patient_name, glucose_value, trend_arrow, timestamp)
+        # Persist every observed reading to the history time-series, deduplicated
+        # by the sensor's own timestamp. Done here — before the staleness/alert
+        # logic — so the record is captured on every cycle regardless of whether
+        # a dashboard client is connected, and regardless of whether the reading
+        # is fresh enough to alert on.
+        try:
+            log_reading_if_new(rh_path, patient_id, patient_name, glucose_value, timestamp)
+        except Exception as exc:  # never let history logging break the alert path
+            logger.warning("Failed to persist reading history for %s: %s", patient_name, exc)
         patient_state = get_patient_state(state, patient_id)
         if is_stale(timestamp, max_age):
             # Silence is an event, not an absence: escalate instead of
@@ -261,8 +277,8 @@ def run_once(
     max_days = config.get("alert_history_max_days", 7)
     cleanup_old_alerts(db_path, max_days)
 
-    # Prune the glucose reading history (written by the dashboard cache
-    # enrichment) so health data is not retained on disk indefinitely.
+    # Prune the glucose reading history (written above on every cycle) so
+    # health data is not retained on disk indefinitely.
     reading_max_days = config.get("reading_history_max_days", 90)
     cleanup_old_readings(get_reading_history_db_path(config), reading_max_days)
 

--- a/src/reading_history.py
+++ b/src/reading_history.py
@@ -18,6 +18,7 @@ Public API
 * :func:`cleanup_old_readings` — delete readings beyond the retention window
 """
 import logging
+import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -86,6 +87,47 @@ def log_reading(
         )
         session.commit()
     logger.debug("Reading logged for patient %s: %d mg/dL", patient_id, glucose_value)
+
+
+# Per-patient sensor timestamp of the last reading we persisted, used by
+# ``log_reading_if_new`` to skip re-logging a frozen sensor's repeated value
+# every polling cycle (which would inflate the series with fake flat segments
+# and bias TIR/CV). State is in-memory: on process restart the dict is empty,
+# so the first reading per patient re-logs even if its sensor timestamp already
+# exists in the DB — at most one duplicate row per patient per restart. That is
+# harmless and, critically, never drops a reading.
+_last_logged_source_ts: dict[str, str] = {}
+_last_logged_lock = threading.Lock()
+
+
+def log_reading_if_new(
+    db_path: str,
+    patient_id: str,
+    patient_name: str,
+    glucose_value: int,
+    source_ts: str,
+) -> bool:
+    """Persist a reading only when its sensor timestamp is new for this patient.
+
+    *source_ts* is the sensor's own measurement timestamp (not our poll time).
+    When it matches the last value we logged for *patient_id*, the reading is a
+    duplicate of a still/frozen sensor and is skipped. Any new (or missing)
+    timestamp is logged — we prefer an occasional duplicate over losing data.
+
+    Returns ``True`` if a row was written, ``False`` if it was deduplicated.
+
+    This is the single writer of reading history: the polling daemon calls it
+    every cycle so the time-series is captured continuously, independent of
+    whether any dashboard client is connected.
+    """
+    source_ts = str(source_ts or "")
+    with _last_logged_lock:
+        if source_ts and _last_logged_source_ts.get(patient_id) == source_ts:
+            return False
+        log_reading(db_path, patient_id, patient_name, glucose_value)
+        if source_ts:
+            _last_logged_source_ts[patient_id] = source_ts
+        return True
 
 
 def get_readings(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -355,15 +355,14 @@ class TestLoadAndEnrichCache:
             )
 
 
-    def test_load_and_enrich_cache_persists_readings_to_history_db(
+    def test_load_and_enrich_cache_does_not_write_history(
         self, tmp_cache, tmp_path, monkeypatch
     ):
-        """Regression: _load_and_enrich_cache() must call log_reading() (singular)
-        for each patient so that /api/patients/{id}/history returns real data.
-
-        This guards against the bug where log_readings() (plural, non-existent)
-        was called instead, causing an empty reading history and
-        'Sin datos suficientes' in the dashboard sparklines.
+        """The dashboard is a read-only consumer of reading history. Persistence
+        belongs solely to the polling daemon (src/main.run_once), which writes
+        every cycle whether or not a client is connected. This guards against
+        re-coupling history capture to dashboard HTTP traffic — the bug that
+        silently starved the time-series when nobody had the dashboard open.
         """
         import src.reading_history as rh
 
@@ -376,12 +375,11 @@ class TestLoadAndEnrichCache:
         ])
         api_module._load_and_enrich_cache()
 
-        readings_p1 = rh.get_readings(str(db_file), "p1", hours=3)
-        readings_p2 = rh.get_readings(str(db_file), "p2", hours=3)
-        assert len(readings_p1) >= 1, "p1 readings must be persisted to history DB"
-        assert readings_p1[-1]["glucose_value"] == 120
-        assert len(readings_p2) >= 1, "p2 readings must be persisted to history DB"
-        assert readings_p2[-1]["glucose_value"] == 95
+        # Cache is loaded for serving...
+        assert "p1" in api_module._readings_cache
+        # ...but nothing was written to the history DB by the dashboard.
+        assert rh.get_readings(str(db_file), "p1", hours=3) == []
+        assert rh.get_readings(str(db_file), "p2", hours=3) == []
 
 
 # ── PWA auth-exempt ──────────────────────────────────────────────────────────

--- a/tests/test_reading_history_dedup.py
+++ b/tests/test_reading_history_dedup.py
@@ -1,99 +1,62 @@
 """Stale readings must not be re-logged to reading_history on every poll.
 
 When a patient's sensor goes silent, every poll cycle re-delivers the same
-last reading. _load_and_enrich_cache used to log it to reading_history.db
-each time, producing fake flat segments in the dashboard charts and
-inflating n_readings/TIR/CV in the history metrics. Readings are now
-deduplicated by the sensor's own timestamp.
+last reading. Logging it each time produces fake flat segments in the
+dashboard charts and inflates n_readings/TIR/CV in the history metrics.
+``log_reading_if_new`` deduplicates by the sensor's own timestamp.
+
+The dedup now lives in src.reading_history (called by the polling daemon on
+every cycle) rather than in the dashboard's cache-enrichment path, so the
+history is captured continuously whether or not a client is connected.
 """
-import json
-import os
 from unittest.mock import MagicMock
 
 import pytest
 
-import src.api as api_module
+import src.reading_history as rh
 
 
 @pytest.fixture()
-def cache_env(tmp_path, monkeypatch):
-    """Point the api module at a temp cache file and a mocked history DB."""
-    cache_file = tmp_path / "readings_cache.json"
-    config = {"api": {"cache_file": str(cache_file)}}
-    monkeypatch.setattr(api_module, "_config", config)
-    monkeypatch.setattr(api_module, "_last_mtime", 0.0)
-    monkeypatch.setattr(api_module, "_last_logged_source_ts", {})
-    with api_module._cache_lock:
-        api_module._readings_cache.clear()
-
-    log_reading = MagicMock()
-    monkeypatch.setattr(
-        api_module,
-        "_reading_history",
-        type(
-            "Stub",
-            (),
-            {
-                "init_db": staticmethod(lambda *a, **k: None),
-                "log_reading": staticmethod(log_reading),
-            },
-        )(),
-    )
-
-    mtime = [1000.0]
-
-    def write_cache(readings):
-        cache_file.write_text(json.dumps({"readings": readings}))
-        # Force a distinct mtime so the loader re-reads the file each time.
-        mtime[0] += 10
-        os.utime(cache_file, (mtime[0], mtime[0]))
-
-    return {"write": write_cache, "log_reading": log_reading}
+def log_spy(monkeypatch):
+    """Spy on the underlying writer and reset the in-memory dedup state."""
+    monkeypatch.setattr(rh, "_last_logged_source_ts", {})
+    spy = MagicMock()
+    monkeypatch.setattr(rh, "log_reading", spy)
+    return spy
 
 
-def _reading(pid, value, ts):
-    return {
-        "patient_id": pid,
-        "patient_name": f"Patient {pid}",
-        "value": value,
-        "trend_arrow": "→",
-        "timestamp": ts,
-    }
+def _log(pid, value, ts):
+    return rh.log_reading_if_new("unused.db", pid, f"Patient {pid}", value, ts)
 
 
-def test_same_sensor_timestamp_logged_once(cache_env):
-    cache_env["write"]([_reading("p1", 110, "2026-06-06 10:00:00+00:00")])
-    api_module._load_and_enrich_cache()
-    cache_env["write"]([_reading("p1", 110, "2026-06-06 10:00:00+00:00")])
-    api_module._load_and_enrich_cache()
-    assert cache_env["log_reading"].call_count == 1
-
-
-def test_new_sensor_timestamp_logged_again(cache_env):
-    cache_env["write"]([_reading("p1", 110, "2026-06-06 10:00:00+00:00")])
-    api_module._load_and_enrich_cache()
-    cache_env["write"]([_reading("p1", 112, "2026-06-06 10:05:00+00:00")])
-    api_module._load_and_enrich_cache()
-    assert cache_env["log_reading"].call_count == 2
-
-
-def test_dedup_is_per_patient(cache_env):
+def test_same_sensor_timestamp_logged_once(log_spy):
     ts = "2026-06-06 10:00:00+00:00"
-    cache_env["write"]([_reading("p1", 110, ts), _reading("p2", 95, ts)])
-    api_module._load_and_enrich_cache()
-    # p1 stale, p2 advanced
-    cache_env["write"]([_reading("p1", 110, ts), _reading("p2", 99, "2026-06-06 10:05:00+00:00")])
-    api_module._load_and_enrich_cache()
-    logged_pids = [c.args[1] for c in cache_env["log_reading"].call_args_list]
+    assert _log("p1", 110, ts) is True
+    assert _log("p1", 110, ts) is False
+    assert log_spy.call_count == 1
+
+
+def test_new_sensor_timestamp_logged_again(log_spy):
+    assert _log("p1", 110, "2026-06-06 10:00:00+00:00") is True
+    assert _log("p1", 112, "2026-06-06 10:05:00+00:00") is True
+    assert log_spy.call_count == 2
+
+
+def test_dedup_is_per_patient(log_spy):
+    ts = "2026-06-06 10:00:00+00:00"
+    _log("p1", 110, ts)
+    _log("p2", 95, ts)
+    # p1 stale (same ts), p2 advanced
+    _log("p1", 110, ts)
+    _log("p2", 99, "2026-06-06 10:05:00+00:00")
+    logged_pids = [c.args[1] for c in log_spy.call_args_list]
     assert logged_pids.count("p1") == 1
     assert logged_pids.count("p2") == 2
 
 
-def test_missing_timestamp_still_logged(cache_env):
-    """Readings without a sensor timestamp fall back to always logging."""
-    r = _reading("p1", 110, "")
-    cache_env["write"]([r])
-    api_module._load_and_enrich_cache()
-    cache_env["write"]([r])
-    api_module._load_and_enrich_cache()
-    assert cache_env["log_reading"].call_count == 2
+def test_missing_timestamp_still_logged(log_spy):
+    """Readings without a sensor timestamp fall back to always logging —
+    we prefer an occasional duplicate over silently dropping data."""
+    assert _log("p1", 110, "") is True
+    assert _log("p1", 110, "") is True
+    assert log_spy.call_count == 2

--- a/tests/test_run_once.py
+++ b/tests/test_run_once.py
@@ -61,6 +61,17 @@ class _MockOutput:
         self.send_alert = MagicMock(return_value=self._success)
 
 
+@pytest.fixture(autouse=True)
+def reading_history_spy(monkeypatch):
+    """run_once now persists reading history on every cycle. Stub the writer so
+    unrelated tests neither touch a real DB nor carry dedup state between tests.
+    Tests that care about persistence request this fixture and assert on it."""
+    monkeypatch.setattr("src.main.init_reading_history_db", lambda *a, **k: None)
+    spy = MagicMock()
+    monkeypatch.setattr("src.main.log_reading_if_new", spy)
+    return spy
+
+
 # ---------------------------------------------------------------------------
 # No readings obtained
 # ---------------------------------------------------------------------------
@@ -539,6 +550,58 @@ def test_multiple_patients_processed_independently():
     saved_state = mock_save.call_args[0][1]
     assert "p2" in saved_state
     assert saved_state.get("p1", {}) == {} or "p1" not in saved_state
+
+
+# ---------------------------------------------------------------------------
+# Reading-history persistence (the poller is the single writer)
+# ---------------------------------------------------------------------------
+
+def test_run_once_persists_every_reading_to_history(reading_history_spy):
+    """Each reading is written to history with (path, pid, name, value, ts),
+    independent of the alert outcome."""
+    normal = _fresh_reading(glucose=120, patient_id="p1", patient_name="Alice")
+    low = _fresh_reading(glucose=55, patient_id="p2", patient_name="Bob")
+
+    mock_output = _MockOutput(success=True)
+
+    with (
+        patch("src.main.init_db"),
+        patch("src.main.load_state", return_value={}),
+        patch("src.main.save_state"),
+        patch("src.main.read_all_patients", return_value=[normal, low]),
+        patch("src.main._save_readings_cache"),
+        patch("src.main.log_alert"),
+        patch("src.main.cleanup_old_alerts"),
+        patch("src.main.cleanup_old_readings"),
+        patch("src.main.build_outputs", return_value=[mock_output]),
+    ):
+        run_once(_config())
+
+    assert reading_history_spy.call_count == 2
+    by_pid = {c.args[1]: c.args for c in reading_history_spy.call_args_list}
+    assert by_pid["p1"][2] == "Alice" and by_pid["p1"][3] == 120
+    assert by_pid["p2"][2] == "Bob" and by_pid["p2"][3] == 55
+
+
+def test_run_once_persists_even_stale_readings(reading_history_spy):
+    """A stale reading is not alertable but MUST still be recorded — history
+    capture is independent of staleness so no data is lost."""
+    stale = _fresh_reading(glucose=120, patient_id="p1", age_seconds=3600)
+
+    with (
+        patch("src.main.init_db"),
+        patch("src.main.load_state", return_value={}),
+        patch("src.main.save_state"),
+        patch("src.main.read_all_patients", return_value=[stale]),
+        patch("src.main._save_readings_cache"),
+        patch("src.main.log_alert"),
+        patch("src.main.cleanup_old_alerts"),
+        patch("src.main.cleanup_old_readings"),
+    ):
+        run_once(_config())
+
+    assert reading_history_spy.call_count == 1
+    assert reading_history_spy.call_args.args[1] == "p1"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problema

El histórico de glucosas (`reading_history.db`) solo lo escribía el proceso del **dashboard** dentro de `_load_and_enrich_cache()`, que corre en startup y en cada hit a endpoint autenticado (lo dispara el auto-refresh del navegador cada 30 s). Resultado: el time-series solo se acumulaba **mientras alguien tenía el dashboard abierto** — denso al verlo, 1-4 puntos/día en miradas breves, y hueco total cuando nadie miraba (verificado en prod: colapso desde 15-jun, 0 filas el 20-21).

El diseño original (según el docstring de `reading_history.py`) tenía a `run_once` logueando en cada ciclo. Esto lo restaura.

## Cambios

- `reading_history.log_reading_if_new()`: hogar único del dedup por timestamp de sensor (antes inline en `api.py`).
- `run_once()` persiste cada lectura observada **antes** de la rama de staleness/alerta → captura continua, independiente del tráfico del dashboard y de si la lectura es fresca.
- `api.py` queda como consumidor **solo-lectura** de `reading_history.db` → un solo escritor (sin contención de escritura SQLite entre procesos).
- Tests: dedup reubicado; persistencia de `run_once` + captura de lecturas stale; guardrail de que el dashboard no escribe.

Suite: **884 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)